### PR TITLE
seems to fix some repomd.xml metalink issues on rhel

### DIFF
--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -10,8 +10,20 @@
   command: setenforce 0
   ignore_errors: yes
 
+- name: reset epel repos
+  command: rm -rf /etc/yum.repos.d/epel.repo
+  ignore_errors: yes
+
 - name: install centos and epel repos
   command: yum -y install centos-release-gluster epel-release
+
+- name: delete cache
+  command: rm -rf /var/cache/yum/*
+  ignore_errors: yes
+
+- name: clean metadata and cache
+  command: yum clean all
+  ignore_errors: yes
 
 - name: setup kubernetes repo
   copy: src=kubernetes.repo owner=root group=root dest=/etc/yum.repos.d


### PR DESCRIPTION
fixes #60 (at least on RHEL and if it still is flakey, the addition of this is not harmful)

I was able to reproduce this issue pretty regularly by removing the deletion of cache and 'yum clean all' after 'yum install' of epel repo

Not saying this will completely fix this issue, but it seems to have done the trick on my setup and like stated, it won't hurt to have those 2 commands enabled in the tasks.

My Set up is RHEL 7.2 using VirtualBox 5.0 as my provider.