### PR TITLE
Update template files from heketi project.

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.json
+++ b/deploy/kube-templates/glusterfs-daemonset.json
@@ -59,6 +59,10 @@
                                 "mountPath": "/dev"
                             },
                             {
+                                "name": "glusterfs-misc",
+                                "mountPath": "/var/lib/misc/glusterfsd"
+                            },
+                            {
                                 "name": "glusterfs-cgroup",
                                 "mountPath": "/sys/fs/cgroup"
                             }
@@ -129,6 +133,12 @@
                         "name": "glusterfs-dev",
                         "hostPath": {
                             "path": "/dev"
+                        }
+                    },
+                    {
+                        "name": "glusterfs-misc",
+                        "hostPath": {
+                            "path": "/var/lib/misc/glusterfsd"
                         }
                     },
                     {

--- a/deploy/ocp-templates/deploy-heketi-template.json
+++ b/deploy/ocp-templates/deploy-heketi-template.json
@@ -125,6 +125,10 @@
                     "value": "/var/lib/heketi/fstab"
                   },
                   {
+                    "name": "HEKETI_SNAPSHOT_LIMIT",
+                    "value": "14"
+                  },
+                  {
                     "name": "HEKETI_KUBE_CERTFILE",
                     "value": "${HEKETI_KUBE_CERTFILE}"
                   },

--- a/deploy/ocp-templates/glusterfs-template.json
+++ b/deploy/ocp-templates/glusterfs-template.json
@@ -78,6 +78,10 @@
                                         "mountPath": "/dev"
                                     },
                                     {
+                                        "name": "glusterfs-misc",
+                                        "mountPath": "/var/lib/misc/glusterfsd"
+                                    },
+                                    {
                                         "name": "glusterfs-cgroup",
                                         "mountPath": "/sys/fs/cgroup"
                                     }
@@ -157,6 +161,12 @@
                                 "name": "glusterfs-dev",
                                 "hostPath": {
                                     "path": "/dev"
+                                }
+                            },
+                            {
+                                "name": "glusterfs-misc",
+                                "hostPath": {
+                                    "path": "/var/lib/misc/glusterfsd"
                                 }
                             },
                             {


### PR DESCRIPTION
Update the kube and ocp tempaltes files for GlusterFS to fix a bug
where some Gluster information wasn't being persisted. Also add a
missing argument to the heketi kube template file.