### PR TITLE
Changing logging option in help section

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -67,7 +67,7 @@ Options:
   -w SECONDS, --wait SECONDS
               Wait SECONDS seconds for pods to become ready. Default is '${WAIT}'.
 
-  -l LOG_FILE, --log LOG_FILE
+  -l LOG_FILE, --log-file LOG_FILE
               Save all output to the specified file.
 
   --abort     Abort a deployment. WARNING: Deletes all related resources.


### PR DESCRIPTION
This closes the #97 and changes have been in the documentation to handle the developer intended behaviour of the script to use a `--log-file ` option instead of the` --log` option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/98)
<!-- Reviewable:end -->
