### PR TITLE
Add immediate flag to all firewalld cmds

### DIFF
--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -67,7 +67,7 @@
 # you will need to update this if you are using a different
 # network provider, or a different CIDR for whatever reason
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-source=10.32.0.0/12`
-- firewalld: source=10.32.0.0/12 zone=trusted permanent=true state=enabled
+- firewalld: source=10.32.0.0/12 zone=trusted permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=10250`
 - firewalld: port=10250/tcp zone=trusted permanent=true state=enabled immediate=true
@@ -77,5 +77,3 @@
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=9898`
 - firewalld: port=9898/tcp zone=trusted permanent=true state=enabled immediate=true
-
-- command: firewall-cmd --reload


### PR DESCRIPTION
This ensures that all rules are applied for current runtime and also
permanently. Hence, removed the redundant reload firewalld operation.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/99)
<!-- Reviewable:end -->
