### PR TITLE
Updates for heketi autoconfig

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -459,11 +459,7 @@ kubeapi=$(${CLI} config view -o jsonpath="{.clusters[?(@.name==\"$cluster\")].cl
 
 if [[ ${LOAD} -eq 0 ]]; then
   if [[ "${CLI}" == *oc* ]]; then
-    ${CLI} process deploy-heketi -v \
-           HEKETI_KUBE_NAMESPACE=${NAMESPACE} \
-           HEKETI_KUBE_INSECURE=y \
-           HEKETI_KUBE_SECRETNAME="${heketi_secret}" \
-           HEKETI_KUBE_APIHOST="${kubeapi}" | ${CLI} create -f -
+    ${CLI} process deploy-heketi | ${CLI} create -f -
   else
     ${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml
   fi
@@ -524,11 +520,7 @@ check_pods "job-name=heketi-storage-copy-job" "Completed"
 ${CLI} delete all,service,jobs,deployment,secret --selector="deploy-heketi"
 
 if [[ "${CLI}" == *oc* ]]; then
-  ${CLI} process heketi -v \
-         HEKETI_KUBE_NAMESPACE=${NAMESPACE} \
-         HEKETI_KUBE_INSECURE=y \
-         HEKETI_KUBE_SECRETNAME="${heketi_secret}" \
-         HEKETI_KUBE_APIHOST="${kubeapi}" | ${CLI} create -f -
+  ${CLI} process heketi | ${CLI} create -f -
 else
   ${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml
 fi

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -465,9 +465,7 @@ if [[ ${LOAD} -eq 0 ]]; then
            HEKETI_KUBE_SECRETNAME="${heketi_secret}" \
            HEKETI_KUBE_APIHOST="${kubeapi}" | ${CLI} create -f -
   else
-    sed -e "s#<HEKETI_KUBE_NAMESPACE>#\"${NAMESPACE}\"#" \
-        -e "s#<HEKETI_KUBE_SECRETNAME>#\"${heketi_secret}\"#" \
-        -e "s#<HEKETI_KUBE_APIHOST>#\"${kubeapi}\"#" ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f -
+    ${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml
   fi
 fi
 
@@ -532,9 +530,7 @@ if [[ "${CLI}" == *oc* ]]; then
          HEKETI_KUBE_SECRETNAME="${heketi_secret}" \
          HEKETI_KUBE_APIHOST="${kubeapi}" | ${CLI} create -f -
 else
-  sed -e "s#<HEKETI_KUBE_NAMESPACE>#\"${NAMESPACE}\"#" \
-      -e "s#<HEKETI_KUBE_SECRETNAME>#\"${heketi_secret}\"#" \
-      -e "s#<HEKETI_KUBE_APIHOST>#\"${kubeapi}\"#" ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f -
+  ${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml
 fi
 
 output -n "Waiting for heketi pod to start ... "

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -421,42 +421,6 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   output "OK"
 fi
 
-sa_secrets=""
-while [[ "x${sa_secrets}" == "x" ]]; do
-  sa_secrets=$(${CLI} get sa heketi-service-account -o="go-template" --template="{{range .secrets}}{{.name}}{{\"\n\"}}{{end}}" 2>&1)
-done
-if [[ "${sa_secrets}" == error* ]]; then
-  output "Error getting service account secrets. Is your KUBECONFIG set correctly?"
-  abort
-fi
-
-heketi_secret=""
-for secret in ${sa_secrets}; do
-  namespace=$(${CLI} get secret/${secret} -o go-template --template="{{.metadata.namespace}}")
-  stype=$(${CLI} get secret/${secret} -o="go-template" --template="{{.type}}")
-  if [[ "${namespace}" == "${NAMESPACE}" ]] && [[ "${stype}" = "kubernetes.io/service-account-token" ]]; then
-    debug "Found secret '$secret' in namespace '$namespace' for heketi-service-account."
-    heketi_secret="${secret}"
-    break
-  else
-    debug "Secret '$secret' in namespace '$namespace' not valid."
-  fi
-done
-
-if [[ "x${heketi_secret}" == "x" ]]; then
-  output "Could not find secret for heketi service account."
-  abort
-fi
-
-context=$(${CLI} config current-context 2>&1)
-if [[ "${context}" == error* ]]; then
-  output "Error getting Kubernetes context. Is your KUBECONFIG set correctly?"
-  abort
-fi
-
-cluster=$(${CLI} config view -o jsonpath="{.contexts[?(@.name==\"$context\")].context.cluster}")
-kubeapi=$(${CLI} config view -o jsonpath="{.clusters[?(@.name==\"$cluster\")].cluster.server}")
-
 if [[ ${LOAD} -eq 0 ]]; then
   if [[ "${CLI}" == *oc* ]]; then
     ${CLI} process deploy-heketi | ${CLI} create -f -

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         name: deploy-heketi
         glusterfs: heketi-pod
     spec:
+      serviceAccountName: heketi-service-account
       containers:
       - image: heketi/heketi:dev
         imagePullPolicy: Always
@@ -43,27 +44,17 @@ spec:
           value: kubernetes
         - name: HEKETI_KUBE_USE_SECRET
           value: "y"
-        - name: HEKETI_KUBE_TOKENFILE
-          value: "/var/lib/heketi/secret/token"
         - name: HEKETI_FSTAB
           value: "/var/lib/heketi/fstab"
         - name: HEKETI_SNAPSHOT_LIMIT
           value: '14'
-        - name: HEKETI_KUBE_INSECURE
-          value: "y"
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET
           value: "y"
-        - name: HEKETI_KUBE_NAMESPACE
-          value: <HEKETI_KUBE_NAMESPACE>
-        - name: HEKETI_KUBE_APIHOST
-          value: <HEKETI_KUBE_APIHOST>
         ports:
         - containerPort: 8080
         volumeMounts:
         - name: db
           mountPath: "/var/lib/heketi"
-        - name: secret
-          mountPath: "/var/lib/heketi/secret"
         readinessProbe:
           timeoutSeconds: 3
           initialDelaySeconds: 3
@@ -78,6 +69,3 @@ spec:
             port: 8080
       volumes:
       - name: db
-      - name: secret
-        secret:
-          secretName: <HEKETI_KUBE_SECRETNAME>

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         name: heketi
         glusterfs: heketi-pod
     spec:
+      serviceAccountName: heketi-service-account
       containers:
       - image: heketi/heketi:dev
         imagePullPolicy: Always
@@ -42,31 +43,17 @@ spec:
           value: kubernetes
         - name: HEKETI_KUBE_USE_SECRET
           value: "y"
-        - name: HEKETI_KUBE_TOKENFILE
-          value: "/var/lib/heketi/secret/token"
-        - name: HEKETI_KUBE_NAMESPACEFILE
-          value: "/var/lib/heketi/secret/namespace"
         - name: HEKETI_FSTAB
           value: "/var/lib/heketi/fstab"
         - name: HEKETI_SNAPSHOT_LIMIT
           value: '14'
-        - name: HEKETI_KUBE_INSECURE
-          value: "y"
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET
           value: "y"
-        - name: HEKETI_KUBE_NAMESPACEFILE
-          value: "/var/lib/heketi/secret/namespace"
-        - name: HEKETI_KUBE_NAMESPACE
-          value: <HEKETI_KUBE_NAMESPACE>
-        - name: HEKETI_KUBE_APIHOST
-          value: <HEKETI_KUBE_APIHOST>
         ports:
         - containerPort: 8080
         volumeMounts:
         - name: db
           mountPath: "/var/lib/heketi"
-        - name: secret
-          mountPath: "/var/lib/heketi/secret"
         readinessProbe:
           timeoutSeconds: 3
           initialDelaySeconds: 3
@@ -84,6 +71,3 @@ spec:
         glusterfs:
           endpoints: heketi-storage-endpoints
           path: heketidbstorage
-      - name: secret
-        secret:
-          secretName: <HEKETI_KUBE_SECRETNAME>

--- a/deploy/ocp-templates/deploy-heketi-template.yaml
+++ b/deploy/ocp-templates/deploy-heketi-template.yaml
@@ -64,6 +64,7 @@ objects:
       strategy:
         type: Replace
       spec:
+        serviceAccountName: heketi-service-account
         containers:
         - name: deploy-heketi
           image: heketi/heketi:dev
@@ -76,29 +77,19 @@ objects:
             value: kubernetes
           - name: HEKETI_KUBE_USE_SECRET
             value: "y"
-          - name: HEKETI_KUBE_TOKENFILE
-            value: /var/lib/heketi/secret/token
           - name: HEKETI_FSTAB
             value: /var/lib/heketi/fstab
           - name: HEKETI_SNAPSHOT_LIMIT
             value: '14'
           - name: HEKETI_KUBE_CERTFILE
             value: ${HEKETI_KUBE_CERTFILE}
-          - name: HEKETI_KUBE_INSECURE
-            value: ${HEKETI_KUBE_INSECURE}
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
             value: "y"
-          - name: HEKETI_KUBE_NAMESPACE
-            value: ${HEKETI_KUBE_NAMESPACE}
-          - name: HEKETI_KUBE_APIHOST
-            value: ${HEKETI_KUBE_APIHOST}
           ports:
           - containerPort: 8080
           volumeMounts:
           - name: db
             mountPath: /var/lib/heketi
-          - name: secret
-            mountPath: /var/lib/heketi/secret
           readinessProbe:
             timeoutSeconds: 3
             initialDelaySeconds: 3
@@ -113,9 +104,6 @@ objects:
               port: 8080
         volumes:
         - name: db
-        - name: secret
-          secret:
-            secretName: ${HEKETI_KUBE_SECRETNAME}
 parameters:
 - name: HEKETI_USER_KEY
   displayName: Heketi User Secret
@@ -126,19 +114,3 @@ parameters:
 - name: HEKETI_KUBE_CERTFILE
   displayName: Certificate file
   description: Container path to Kubernetes certificate file
-- name: HEKETI_KUBE_INSECURE
-  displayName: Insecure access
-  description: Allow insecure SSL/HTTPS access
-  value: "n"
-- name: HEKETI_KUBE_SECRETNAME
-  displayName: Kube API secret
-  description: Secret to use for accessing the Kubernetes API
-  required: true
-- name: HEKETI_KUBE_NAMESPACE
-  displayName: Project/Namespace
-  description: OpenShift project or Kubernetes namespace containing GlusterFS
-  required: true
-- name: HEKETI_KUBE_APIHOST
-  displayName: API Host Address
-  description: 'Kubernetes API host, for example: https://ip:port'
-  required: true

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -59,6 +59,7 @@ objects:
       strategy:
         type: Recreate
       spec:
+        serviceAccountName: heketi-service-account
         containers:
         - name: heketi
           image: heketi/heketi:dev
@@ -70,24 +71,16 @@ objects:
             value: ${HEKETI_ADMIN_KEY}
           - name: HEKETI_EXECUTOR
             value: kubernetes
+          - name: HEKETI_KUBE_USE_SECRET
+            value: "y"
           - name: HEKETI_FSTAB
             value: /var/lib/heketi/fstab
           - name: HEKETI_SNAPSHOT_LIMIT
             value: '14'
           - name: HEKETI_KUBE_CERTFILE
             value: ${HEKETI_KUBE_CERTFILE}
-          - name: HEKETI_KUBE_INSECURE
-            value: ${HEKETI_KUBE_INSECURE}
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
             value: "y"
-          - name: HEKETI_KUBE_USE_SECRET
-            value: "y"
-          - name: HEKETI_KUBE_TOKENFILE
-            value: /var/lib/heketi/secret/token
-          - name: HEKETI_KUBE_NAMESPACE
-            value: ${HEKETI_KUBE_NAMESPACE}
-          - name: HEKETI_KUBE_APIHOST
-            value: ${HEKETI_KUBE_APIHOST}
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -112,9 +105,6 @@ objects:
           glusterfs:
             endpoints: heketi-storage-endpoints
             path: heketidbstorage
-        - name: secret
-          secret:
-            secretName: ${HEKETI_KUBE_SECRETNAME}
 parameters:
 - name: HEKETI_USER_KEY
   displayName: Heketi User Secret
@@ -125,19 +115,3 @@ parameters:
 - name: HEKETI_KUBE_CERTFILE
   displayName: Certificate file
   description: Container path to Kubernetes certificate file
-- name: HEKETI_KUBE_INSECURE
-  displayName: Insecure access
-  description: Allow insecure SSL/HTTPS access
-  value: "n"
-- name: HEKETI_KUBE_SECRETNAME
-  displayName: Kube API secret
-  description: Secret to use for accessing the Kubernetes API
-  required: true
-- name: HEKETI_KUBE_NAMESPACE
-  displayName: Project/Namespace
-  description: OpenShift project or Kubernetes namespace containing GlusterFS
-  required: true
-- name: HEKETI_KUBE_APIHOST
-  displayName: API Host Address
-  description: 'Kubernetes API host, for example: https://ip:port'
-  required: true


### PR DESCRIPTION
The PR https://github.com/heketi/heketi/pull/622 has caused a need to update our deployment. As heketi now uses the heketi-service-account Service Account by default and grabs all its environmental context from that, we no longer have to provide namespace, kubeapi, or even the Service Account secret.

A side-effect of this is that the OpenShift deployment now seems to require that heketi-service-account be priviledged, that is we seem to need:

```
oadm add-scc-to-user privileged system:serviceaccount:<project namespace>:heketi-service-account
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/112)
<!-- Reviewable:end -->
