### PR TITLE
set builtin for handling heketi-cli failures

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 PROG="$(basename "${0}")"
 TOPOLOGY='topology.json'
 LOG_FILE=''
@@ -321,15 +323,15 @@ if [[ ${ABORT} -eq 1 ]]; then
 fi
 
 if [[ "${CLI}" == *oc* ]]; then
-  ${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml
-  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml
-  ${CLI} create -f ${TEMPLATES}/heketi-template.yaml
+  ${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml  || true
+  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml  || true
+  ${CLI} create -f ${TEMPLATES}/heketi-template.yaml         || true
   if [[ $GLUSTER -eq 1 ]]; then
-    ${CLI} create -f ${TEMPLATES}/glusterfs-template.yaml
+    ${CLI} create -f ${TEMPLATES}/glusterfs-template.yaml    || true
   fi
-  ${CLI} policy add-role-to-user edit system:serviceaccount:${NAMESPACE}:heketi-service-account
+  ${CLI} policy add-role-to-user edit system:serviceaccount:${NAMESPACE}:heketi-service-account || true
 else
-  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml
+  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml || true
 fi
 
 if [[ $GLUSTER -eq 1 ]]; then


### PR DESCRIPTION
Using the setbuiltin to handle command line execution errors and also handle the unset variables in the  deploy script 

Pair Programmed with @raghavendra-talur

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/113)
<!-- Reviewable:end -->
