### PR TITLE
Revert "set builtin for handling heketi-cli failures"

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-
 PROG="$(basename "${0}")"
 TOPOLOGY='topology.json'
 LOG_FILE=''
@@ -370,15 +368,15 @@ if [[ ${ABORT} -eq 1 ]]; then
 fi
 
 if [[ "${CLI}" == *oc* ]]; then
-  ${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml  || true
-  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml  || true
-  ${CLI} create -f ${TEMPLATES}/heketi-template.yaml         || true
+  ${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml
+  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml
+  ${CLI} create -f ${TEMPLATES}/heketi-template.yaml
   if [[ $GLUSTER -eq 1 ]]; then
-    ${CLI} create -f ${TEMPLATES}/glusterfs-template.yaml    || true
+    ${CLI} create -f ${TEMPLATES}/glusterfs-template.yaml
   fi
-  ${CLI} policy add-role-to-user edit system:serviceaccount:${NAMESPACE}:heketi-service-account || true
+  ${CLI} policy add-role-to-user edit system:serviceaccount:${NAMESPACE}:heketi-service-account
 else
-  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml || true
+  ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml
 fi
 
 if [[ $GLUSTER -eq 1 ]]; then


### PR DESCRIPTION
Unfortunately this patch proved to be too strict for our requirements.
We will add selective error handling in subsequent patches.

This reverts commit 2426eaf2572717e1a972d4cf420d86a243ccb799.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/118)
<!-- Reviewable:end -->
