### PR TITLE
resolve that can't modprobe dm_thin_pool module

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -41,6 +41,8 @@ spec:
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
           mountPath: "/sys/fs/cgroup"
+        - name: glusterfs-lib-modules
+          mountPath: "/lib/modules"
         securityContext:
           capabilities: {}
           privileged: true
@@ -86,3 +88,6 @@ spec:
       - name: glusterfs-cgroup
         hostPath:
           path: "/sys/fs/cgroup"
+      - name: glusterfs-lib-modules
+        hostPath:
+          path: "/lib/modules"


### PR DESCRIPTION
I found the issue that was failed to run glusterfs-daemonset.yaml on coreos. The reason is lvm couldn't initial correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/140)
<!-- Reviewable:end -->
