### PR TITLE
Updated gk-deploy to fix CLI select globs

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -114,7 +114,7 @@ abort() {
   ${CLI} delete dc,svc,routes heketi
   ${CLI} delete svc/heketi-storage-endpoints
   ${CLI} delete sa heketi-service-account
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     ${CLI} delete template deploy-heketi
     ${CLI} delete template heketi
   fi
@@ -124,7 +124,7 @@ abort() {
       ${CLI} label nodes ${node} storagenode-
     done <<< "$(echo -e "${NODES}")"
     ${CLI} delete all,service,jobs,ds,secret --selector="glusterfs"
-    if [[ "${CLI}" == *oc* ]]; then
+    if [[ "${CLI}" == *oc ]]; then
       ${CLI} delete template glusterfs
     fi
   fi
@@ -349,9 +349,9 @@ if [[ "x${CLI}" == "x" ]]; then
   fi
 fi
 
-if [[ "${CLI}" == *oc* ]]; then
+if [[ "${CLI}" == *oc ]]; then
   output "Using OpenShift CLI."
-elif [[ "${CLI}" == *kubectl* ]]; then
+elif [[ "${CLI}" == *kubectl ]]; then
   output "Using Kubernetes CLI."
 else
   output "Unknown CLI '${CLI}'."
@@ -359,7 +359,7 @@ else
 fi
 
 if [[ "x${TEMPLATES}" == "x" ]]; then
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     TEMPLATES="${OCP_TEMPLATES_DEFAULT}"
   else
     TEMPLATES="${KUBE_TEMPLATES_DEFAULT}"
@@ -367,9 +367,9 @@ if [[ "x${TEMPLATES}" == "x" ]]; then
 fi
 
 if [[ -z "$NAMESPACE" ]]; then
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
-  elif [[ "${CLI}" == *kubectl* ]]; then
+  elif [[ "${CLI}" == *kubectl ]]; then
     NAMESPACE=$(${CLI} config current-context)
   fi
   if [[ -z "$NAMESPACE" ]]; then
@@ -399,7 +399,7 @@ read -rp "[Y]es, [N]o? [Default: N]: " abortopt
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     ${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml
     ${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml
     ${CLI} create -f ${TEMPLATES}/heketi-template.yaml
@@ -419,7 +419,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
     ${CLI} label nodes ${node} storagenode=glusterfs
   done <<< "$(echo -e "${NODES}")"
   debug "Deploying GlusterFS pods."
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     ${CLI} process glusterfs | ${CLI} create -f -
   else
     ${CLI} create -f ${TEMPLATES}/glusterfs-daemonset.yaml
@@ -431,7 +431,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     ${CLI} process deploy-heketi | ${CLI} create -f -
   else
     ${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml
@@ -445,7 +445,7 @@ output "OK"
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]]; do
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
   else
     heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
@@ -457,7 +457,7 @@ debug "OK"
 hello=$(curl http://${heketi_service}/hello 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
   output "Failed to communicate with deploy-heketi service."
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     output "Please verify that a router has been properly configured."
   fi
   abort
@@ -492,7 +492,7 @@ check_pods "job-name=heketi-storage-copy-job" "Completed"
 
 ${CLI} delete all,service,jobs,deployment,secret --selector="deploy-heketi"
 
-if [[ "${CLI}" == *oc* ]]; then
+if [[ "${CLI}" == *oc ]]; then
   ${CLI} process heketi | ${CLI} create -f -
 else
   ${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml
@@ -505,7 +505,7 @@ output "OK"
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]]; do
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
   else
     heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
@@ -517,11 +517,10 @@ debug "OK"
 hello=$(curl http://${heketi_service}/hello 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
   output "Failed to communicate with heketi service."
-  if [[ "${CLI}" == *oc* ]]; then
+  if [[ "${CLI}" == *oc ]]; then
     output "Please verify that a router has been properly configured."
   fi
   abort
 else
   output "heketi is now running."
 fi
-


### PR DESCRIPTION
Updated globs for checking CLI tool to not missfire on paths containing 'oc'

Issue raised in: https://github.com/gluster/gluster-kubernetes/issues/145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/148)
<!-- Reviewable:end -->
