### PR TITLE
Better logging

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -160,24 +160,22 @@ assign() {
 check_pods() {
   local all_ready=false
   s=0
-  prestatus=""
+  debug "\nChecking status of pods matching '${1}':"
   while [[ "${all_ready}" != "true" ]]; do
     if [[ ${s} -ge ${WAIT} ]]; then
       output "Timed out waiting for pods matching '${1}'."
       abort
     fi
     sleep 2
-    ((s+=2))
     pods=$(${CLI} get pod --no-headers --show-all --selector="${1}" 2>&1)
-    if [[ "${prestatus}" != "${pods}" ]]; then
-      debug "Checking status of pods matching '${1}':"
-      debug "$pods"
-      prestatus="${pods}"
-    else
-      debug -n "."
+    if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
+      podlines=$(echo "$pods" | wc -l)
+      ((podlines+=1))
+      debug "\033[${podlines}A"
     fi
     all_ready=true
     while read -r pod; do
+      debug "\033[K${pod}"
       case ${2} in
         Completed)
         status=$(echo "${pod}" | awk '{print $3}')
@@ -193,6 +191,7 @@ check_pods() {
         ;;
       esac
     done <<< "$(echo -e "$pods")"
+    ((s+=2))
   done
 }
 

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -97,9 +97,16 @@ output() {
     opts+="n"
     shift
   fi
-  echo "$opts" "${1}"
-  if [[ "${LOG_FILE}" ]]; then
-    echo $opts "${1}" >> "${LOG_FILE}"
+  out="${1}"
+  echo "$opts" "${out}"
+  if [[ "x${LOG_FILE}" != "x" ]]; then
+    if [[ "${out}" == "\033["K* ]]; then
+      out="${out:6}"
+    fi
+    if [[ "${out}" == "\033["*A ]]; then
+      out="---"
+    fi
+    echo $opts "${out}" >> "${LOG_FILE}"
   fi
 }
 


### PR DESCRIPTION
Use terminal escape commands to improve logging. These changes allow check_pods() to not spam the terminal when using `-v` while also translating the output to something legible in the log file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/152)
<!-- Reviewable:end -->
