### PR TITLE
Use heketi's service IP and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ to go. You can set the `HEKETI_CLI_SERVER` environment variable as follows so
 that it can be read directly by `heketi-cli` or sent to something like `curl`:
 
 ```bash
-$ export HEKETI_CLI_SERVER=$(kubectl describe svc/heketi | grep "Endpoints:" | awk '{print "http://"$2}')
+$ export HEKETI_CLI_SERVER=$(kubectl get svc/heketi --template 'http://{{.spec.clusterIP}}:{{(index .spec.ports 0).port}}')
 
 $ echo $HEKETI_CLI_SERVER
 http://10.42.0.0:8080


### PR DESCRIPTION
Updated documentation to fetch the heketi service IP and port instead of the service's endpoint IP and port.  When users follow the docs (base README and hello world README), they set up a storage class that is set up to talk to the heketi pod directly.  This will work but will fail if the pod gets deleted and recreated with a new IP.

The only disadvantage of this PR's approach is that the `jq` package must be installed.  We could look at other one-liners to accomplish this without 3rd party packages but `jq` makes it pretty clean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/156)
<!-- Reviewable:end -->
