### PR TITLE
gk-deploy: default to 'oc' as cli if found.

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -329,23 +329,7 @@ fi
 if [[ "x${CLI}" == "x" ]]; then
   kubectl=$(type kubectl 2>/dev/null | awk '{print $3}')
   oc=$(type oc 2>/dev/null | awk '{print $3}')
-  if [[ "x${kubectl}" != "x" ]] && [[ "x${oc}" != "x" ]]; then
-    output "Multiple CLI options detected. Please select a deployment option."
-    while [[ "x${CLI}" == "x" ]]; do
-      loop=false
-      read -rp "[O]penShift, [K]ubernetes? [O/o/K/k]: " cliopt
-      case $cliopt in
-        O*|o*)
-        CLI="${oc}"
-        ;;
-        K*|k*)
-        CLI="${kubectl}"
-        ;;
-        *)
-        CLI=""
-      esac
-    done
-  elif [[ "x${oc}" != "x" ]]; then
+  if [[ "x${oc}" != "x" ]]; then
     CLI="${oc}"
   elif [[ "x${kubectl}" != "x" ]]; then
     CLI="${kubectl}"


### PR DESCRIPTION
The assumption is that in a OpenShift environment, users want
to use oc. They can still force the use of kubectl with the --cli
switch.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/170)
<!-- Reviewable:end -->
