### PR TITLE
Fix yaml alignment issue

### DIFF
--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -5,9 +5,9 @@ metadata:
   name: heketi-db-backup
   labels:
     glusterfs: heketi-db
-  data:
-    heketi.db: ''
-  type: Opaque
+data:
+  heketi.db: ''
+type: Opaque
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
The deployer fails to deploy because on yaml alignment issue:

```
daemonset "glusterfs" created
Waiting for GlusterFS pods to start ... OK
error: error validating "./kube-templates/heketi-deployment.yaml": error validating data: [found invalid field data for v1.ObjectMeta, found invalid field type for v1.ObjectMeta]; if you choose to ignore these errors, turn validation off with --validate=false
Waiting for heketi pod to start ... Timed out waiting for pods matching 'glusterfs=heketi-pod'.
the server doesn't have a resource type "dc"
serviceaccount "heketi-service-account" deleted
Error from server (NotFound): secrets "heketi-db-backup" not found
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/174)
<!-- Reviewable:end -->
