### PR TITLE
Add encryption support to gluster containers

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -41,6 +41,9 @@ spec:
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
           mountPath: "/sys/fs/cgroup"
+        - name: glusterfs-ssl
+          mountPath: "/etc/ssl"
+          readOnly: true
         securityContext:
           capabilities: {}
           privileged: true
@@ -86,3 +89,6 @@ spec:
       - name: glusterfs-cgroup
         hostPath:
           path: "/sys/fs/cgroup"
+      - name: glusterfs-ssl
+        hostPath:
+          path: "/etc/ssl"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -55,6 +55,9 @@ objects:
           - name: glusterfs-cgroup
             mountPath: "/sys/fs/cgroup"
             readOnly: true
+          - name: glusterfs-ssl
+            mountPath: "/etc/ssl"
+            readOnly: true
           securityContext:
             capabilities: {}
             privileged: true
@@ -109,6 +112,9 @@ objects:
         - name: glusterfs-cgroup
           hostPath:
             path: "/sys/fs/cgroup"
+        - name: glusterfs-ssl
+          hostPath:
+            path: "/etc/ssl"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
Bind mount the /etc/ssl of host to container which can be used for encryption of gluster.

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/176)
<!-- Reviewable:end -->
