### PR TITLE
cgroup should be mounted as readonly

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -41,6 +41,7 @@ spec:
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
           mountPath: "/sys/fs/cgroup"
+          readOnly: true
         - name: glusterfs-ssl
           mountPath: "/etc/ssl"
           readOnly: true


### PR DESCRIPTION
Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/177)
<!-- Reviewable:end -->
