### PR TITLE
check_pods() return code

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -156,14 +156,14 @@ assign() {
 }
 
 check_pods() {
-  local all_ready=false
+  local rc=1
   local wait_limit=${2:-${WAIT}}
   s=0
   debug "\nChecking status of pods matching '${1}':"
-  while [[ "${all_ready}" != "true" ]]; do
+  while [[ ${rc} -ne 0 ]]; do
     if [[ ${s} -ge ${wait_limit} ]]; then
-      output "Timed out waiting for pods matching '${1}'."
-      abort
+      debug "Timed out waiting for pods matching '${1}'."
+      break
     fi
     sleep 2
     pods=$(${CLI} get pod --no-headers --show-all --selector="${1}" 2>&1)
@@ -172,26 +172,28 @@ check_pods() {
       ((podlines+=1))
       debug "\033[${podlines}A"
     fi
-    all_ready=true
+    rc=0
     while read -r pod; do
       debug "\033[K${pod}"
       case ${2} in
         Completed)
         status=$(echo "${pod}" | awk '{print $3}')
         if [[ "${status}" != "Completed" ]]; then
-          all_ready=false
+          rc=1
         fi
         ;;
         *)
         status=$(echo "${pod}" | awk '{print $2}')
         if [[ "${status}" != "1/1" ]]; then
-          all_ready=false
+          rc=1
         fi
         ;;
       esac
     done <<< "$(echo -e "$pods")"
     ((s+=2))
   done
+
+  return ${rc}
 }
 
 while [[ $# -ge 1 ]]; do
@@ -385,11 +387,13 @@ if [[ ${ABORT} -eq 1 ]]; then
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
+  output -n "Checking that heketi pod is not running ... "
   check_pods "glusterfs=heketi-pod" 2
   if [[ $? -eq 0 ]]; then
     output "Found heketi pod running. Please destroy existing setup and try again."
     exit 1
   fi
+  output "OK"
   if [[ "${CLI}" == *oc\ * ]]; then
     tempout=$(${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml 2>&1)
     output "${tempout}"
@@ -425,6 +429,10 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
 
   output -n "Waiting for GlusterFS pods to start ... "
   check_pods "glusterfs-node=pod"
+  if [[ $? -ne 0 ]]; then
+    output "pods not found."
+    abort
+  fi
   output "OK"
 fi
 
@@ -440,6 +448,10 @@ fi
 
 output -n "Waiting for heketi pod to start ... "
 check_pods "glusterfs=heketi-pod"
+if [[ $? -ne 0 ]]; then
+  output "pods not found."
+  abort
+fi
 output "OK"
 
 heketi_service=""

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -155,18 +155,14 @@ assign() {
   keypos=$keylen
 }
 
-are_pods_running() {
-  local all_ready="no"
-  local wait_for=2
+check_pods() {
+  local all_ready=false
   s=0
-  if [ -n "$2" ]; then
-    wait_for="$2"
-  fi
   debug "\nChecking status of pods matching '${1}':"
-  while [[ "${all_ready}" != "yes" ]]; do
-    if [[ ${s} -ge $wait_for ]]; then
+  while [[ "${all_ready}" != "true" ]]; do
+    if [[ ${s} -ge ${WAIT} ]]; then
       output "Timed out waiting for pods matching '${1}'."
-      break
+      abort
     fi
     sleep 2
     pods=$(${CLI} get pod --no-headers --show-all --selector="${1}" 2>&1)
@@ -175,27 +171,26 @@ are_pods_running() {
       ((podlines+=1))
       debug "\033[${podlines}A"
     fi
-    all_ready="yes"
+    all_ready=true
     while read -r pod; do
       debug "\033[K${pod}"
       case ${2} in
         Completed)
         status=$(echo "${pod}" | awk '{print $3}')
         if [[ "${status}" != "Completed" ]]; then
-          all_ready="no"
+          all_ready=false
         fi
         ;;
         *)
         status=$(echo "${pod}" | awk '{print $2}')
         if [[ "${status}" != "1/1" ]]; then
-          all_ready="no"
+          all_ready=false
         fi
         ;;
       esac
     done <<< "$(echo -e "$pods")"
     ((s+=2))
   done
-  echo $all_ready
 }
 
 while [[ $# -ge 1 ]]; do
@@ -389,7 +384,8 @@ if [[ ${ABORT} -eq 1 ]]; then
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
-  if [[ $(are_pods_running "glusterfs=heketi-pod") == "yes" ]]; then
+  check_pods "glusterfs=heketi-pod"
+  if [[ $? -eq 0 ]]; then
     output "Found heketi pod running. Please destroy existing setup and try again."
     exit 1
   fi
@@ -427,9 +423,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   fi
 
   output -n "Waiting for GlusterFS pods to start ... "
-  if [[ $(are_pods_running "glusterfs-node=pod" $WAIT) == "no" ]] ; then
-    abort
-  fi
+  check_pods "glusterfs-node=pod"
   output "OK"
 fi
 
@@ -444,9 +438,7 @@ if [[ ${LOAD} -eq 0 ]]; then
 fi
 
 output -n "Waiting for heketi pod to start ... "
-if [[ $(are_pods_running "glusterfs=heketi-pod" $WAIT) == "no" ]] ; then
-  abort
-fi
+check_pods "glusterfs=heketi-pod"
 output "OK"
 
 heketi_service=""

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -157,10 +157,11 @@ assign() {
 
 check_pods() {
   local all_ready=false
+  local wait_limit=${2:-${WAIT}}
   s=0
   debug "\nChecking status of pods matching '${1}':"
   while [[ "${all_ready}" != "true" ]]; do
-    if [[ ${s} -ge ${WAIT} ]]; then
+    if [[ ${s} -ge ${wait_limit} ]]; then
       output "Timed out waiting for pods matching '${1}'."
       abort
     fi
@@ -384,7 +385,7 @@ if [[ ${ABORT} -eq 1 ]]; then
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
-  check_pods "glusterfs=heketi-pod"
+  check_pods "glusterfs=heketi-pod" 2
   if [[ $? -eq 0 ]]; then
     output "Found heketi pod running. Please destroy existing setup and try again."
     exit 1


### PR DESCRIPTION
Implement and check a return code from check_pods(). Also allow a custom wait timer for a given check_pods() call.

These two commits are in the same PR because they both rely on the revert in the first commit. These are an alternative implementation to #175 due to some issues encountered in testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/181)
<!-- Reviewable:end -->
