### PR TITLE
Fix regression in topology load error reporting

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -479,7 +479,20 @@ else
   output "heketi is now running."
 fi
 
-eval_output "heketi-cli -s http://${heketi_service} topology load --json=${TOPOLOGY} 2>&1"
-if [[ $? -ne 0 ]]; then
-  output "Please check the failed node or device and restart with --load"
+load_temp=$(mktemp)
+eval_output "heketi-cli -s http://${heketi_service} topology load --json=${TOPOLOGY} 2>&1" | tee ${load_temp}
+grep -q "Unable" ${load_temp}
+unable=$?
+rm ${load_temp}
+
+if [[ ${PIPESTATUS[0]} -ne 0 ]] || [[ ${unable} -eq 0 ]]; then
+  output "Error loading the cluster topology."
+  if [[ ${unable} -eq 0 ]]; then
+    output "Please check the failed node or device and rerun this script using the --load option."
+  fi
+  exit 1
+else
+  output "heketi topology loaded."
 fi
+
+output "Ready to create and provide GlusterFS volumes."


### PR DESCRIPTION
Allow the script to detect if a device or node has failed to load
from the topology file and alert the user on what to do. This is
fixing a regression introduced by PR #182.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/183)
<!-- Reviewable:end -->
