### PR TITLE
Freeze on stable versions of component projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Kubernetes.
 
 ### Component Projects
 
-* **[Kubernetes](http://kubernetes.io/)**, the container management system.
-* **[GlusterFS](https://www.gluster.org/)**, the scale-out storage system.
-* **[heketi](https://github.com/heketi/heketi)**, the RESTful volume management
+* **[Kubernetes](http://kubernetes.io/) 1.5**, the container management system.
+* **[GlusterFS](https://www.gluster.org/) 3.9**, the scale-out storage system.
+* **[heketi](https://github.com/heketi/heketi) 4.0**, the RESTful volume management
   interface for GlusterFS.
 
 ### Presentations

--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         storagenode: glusterfs
       hostNetwork: true
       containers:
-      - image: gluster/gluster-centos:latest
+      - image: gluster/gluster-centos:gluster3u9_centos7
         imagePullPolicy: IfNotPresent
         name: glusterfs
         volumeMounts:

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       serviceAccountName: heketi-service-account
       containers:
-      - image: heketi/heketi:dev
+      - image: heketi/heketi:4
         imagePullPolicy: IfNotPresent
         name: heketi
         env:

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -32,7 +32,7 @@ objects:
           storagenode: glusterfs
         hostNetwork: true
         containers:
-        - image: gluster/gluster-centos:latest
+        - image: gluster/gluster-centos:gluster3u9_centos7
           imagePullPolicy: IfNotPresent
           name: glusterfs
           volumeMounts:

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -70,7 +70,7 @@ objects:
         serviceAccountName: heketi-service-account
         containers:
         - name: heketi
-          image: heketi/heketi:dev
+          image: heketi/heketi:4
           imagePullPolicy: IfNotPresent
           env:
           - name: HEKETI_USER_KEY


### PR DESCRIPTION
Use images based on stable releases of our component projects rather than using images based on their master branches. Also update the README to document these versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/190)
<!-- Reviewable:end -->
