### PR TITLE
Add an initial testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: true
+
+script:
+- make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: true
 
+before_install:
+- sudo pip install yamllint
+
 script:
 - make test

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	@true
+	$(MAKE) -C tests test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	@true

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,2 @@
+test:
+	./run.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Testsuite
+
+This contains the testsuite for gluster-kubernetes.
+
+## Prerequisites
+
+The yaml tests require the 'yamllint' program.
+Install it with e.g.
+
+* `dnf install yamllint`, or
+* `pip install yammling`
+
+## TODOs
+
+* Write more tests
+* More elaborate basic tests need fuller mocking/stubbing of tools
+* Write full functional tests to be run in vms
+ (like the kubernetes vagrant environment)
+

--- a/tests/common/subunit.sh
+++ b/tests/common/subunit.sh
@@ -1,0 +1,113 @@
+#
+#  subunit.sh: shell functions to report test status via the subunit protocol.
+#  Copyright (C) 2006  Robert Collins <robertc@robertcollins.net>
+#  Copyright (C) 2008  Jelmer Vernooij <jelmer@samba.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+timestamp() {
+  # mark the start time. With Gnu date, you get nanoseconds from %N
+  # (here truncated to microseconds with %6N), but not on BSDs,
+  # Solaris, etc, which will apparently leave either %N or N at the end.
+  date -u +'time: %Y-%m-%d %H:%M:%S.%6NZ' | sed 's/\..*NZ$/.000000Z/'
+}
+
+subunit_start_test () {
+  # emit the current protocol start-marker for test $1
+  timestamp
+  echo "test: $1"
+}
+
+
+subunit_pass_test () {
+  # emit the current protocol test passed marker for test $1
+  timestamp
+  echo "success: $1"
+}
+
+# This is just a hack as we have some broken scripts
+# which use "exit $failed", without initializing failed.
+failed=0
+
+subunit_fail_test () {
+  # emit the current protocol fail-marker for test $1, and emit stdin as
+  # the error text.
+  # we use stdin because the failure message can be arbitrarily long, and this
+  # makes it convenient to write in scripts (using <<END syntax.
+  timestamp
+  echo "failure: $1 ["
+  cat -
+  echo "]"
+}
+
+
+subunit_error_test () {
+  # emit the current protocol error-marker for test $1, and emit stdin as
+  # the error text.
+  # we use stdin because the failure message can be arbitrarily long, and this
+  # makes it convenient to write in scripts (using <<END syntax.
+  timestamp
+  echo "error: $1 ["
+  cat -
+  echo "]"
+}
+
+subunit_skip_test () {
+  # emit the current protocol skip-marker for test $1, and emit stdin as
+  # the error text.
+  # we use stdin because the failure message can be arbitrarily long, and this
+  # makes it convenient to write in scripts (using <<END syntax.
+  echo "skip: $1 ["
+  cat -
+  echo "]"
+}
+
+testit () {
+	name="$1"
+	shift
+	cmdline="$*"
+	subunit_start_test "$name"
+	output=`$cmdline 2>&1`
+	status=$?
+	if [ x$status = x0 ]; then
+		subunit_pass_test "$name"
+	else
+		echo "$output" | subunit_fail_test "$name"
+	fi
+	return $status
+}
+
+testit_expect_failure () {
+	name="$1"
+	shift
+	cmdline="$*"
+	subunit_start_test "$name"
+	output=`$cmdline 2>&1`
+	status=$?
+	if [ x$status = x0 ]; then
+		echo "$output" | subunit_fail_test "$name"
+	else
+		subunit_pass_test "$name"
+	fi
+	return $status
+}
+
+testok () {
+	name=`basename $1`
+	failed=$2
+
+	exit $failed
+}

--- a/tests/gk-deploy/run.sh
+++ b/tests/gk-deploy/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+echo "running tests in ${SCRIPT_DIR}"
+
+for test in ${SCRIPT_DIR}/test_*.sh ; do
+	$test
+	if [ $? -ne 0 ]; then
+		exit 1
+	fi
+done

--- a/tests/gk-deploy/stubs/kubectl
+++ b/tests/gk-deploy/stubs/kubectl
@@ -2,18 +2,18 @@
 
 SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 
-if [ "x$1" = "xget" ]; then
-	if [ "x$2" != "xnamespaces" ]; then
+if [[ "x$1" == "xget" ]]; then
+	if [[ "x$2" != "xnamespaces" ]]; then
 		echo "USAGE"
 		exit 1
 	fi
 
 	NAMESPACE="$3"
 
-	if [ "$NAMESPACE" = "invalid" ]; then
+	if [[ "$NAMESPACE" == "invalid" ]]; then
 		exit 1
 	fi
-elif [ "x$1" = "xconfig" ]; then
+elif [[ "x$1" == "xconfig" ]]; then
 	echo "aplo"
 fi
 

--- a/tests/gk-deploy/stubs/kubectl
+++ b/tests/gk-deploy/stubs/kubectl
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+
+if [ "x$1" = "xget" ]; then
+	if [ "x$2" != "xnamespaces" ]; then
+		echo "USAGE"
+		exit 1
+	fi
+
+	NAMESPACE="$3"
+
+	if [ "$NAMESPACE" = "invalid" ]; then
+		exit 1
+	fi
+elif [ "x$1" = "xconfig" ]; then
+	echo "aplo"
+fi
+
+exit 0

--- a/tests/gk-deploy/stubs/oc
+++ b/tests/gk-deploy/stubs/oc
@@ -2,18 +2,18 @@
 
 SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 
-if [ "x$1" = "xget" ]; then
-	if [ "x$2" != "xnamespaces" ]; then
+if [[ "x$1" == "xget" ]]; then
+	if [[ "x$2" != "xnamespaces" ]]; then
 		echo "USAGE"
 		exit 1
 	fi
 
 	NAMESPACE="$3"
 
-	if [ "$NAMESPACE" = "invalid" ]; then
+	if [[ "$NAMESPACE" == "invalid" ]]; then
 		exit 1
 	fi
-elif [ "x$1" = "xconfig" ]; then
+elif [[ "x$1" == "xconfig" ]]; then
 	cat ${SCRIPT_DIR}/oc-context.txt
 fi
 

--- a/tests/gk-deploy/stubs/oc
+++ b/tests/gk-deploy/stubs/oc
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+
+if [ "x$1" = "xget" ]; then
+	if [ "x$2" != "xnamespaces" ]; then
+		echo "USAGE"
+		exit 1
+	fi
+
+	NAMESPACE="$3"
+
+	if [ "$NAMESPACE" = "invalid" ]; then
+		exit 1
+	fi
+elif [ "x$1" = "xconfig" ]; then
+	cat ${SCRIPT_DIR}/oc-context.txt
+fi
+
+exit 0

--- a/tests/gk-deploy/stubs/oc-context.txt
+++ b/tests/gk-deploy/stubs/oc-context.txt
@@ -1,0 +1,5 @@
+CURRENT   NAME                                     CLUSTER             AUTHINFO                         NAMESPACE
+          default/192-168-90-5:8443/system:admin   192-168-90-5:8443   system:admin/192-168-90-5:8443   default
+          default/192-168-90-5:8443/test-admin     192-168-90-5:8443   test-admin/192-168-90-5:8443     default
+*         aplo/192-168-90-5:8443/test-admin        192-168-90-5:8443   test-admin/192-168-90-5:8443     aplo
+

--- a/tests/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/gk-deploy/test_gk_deploy_basic.sh
@@ -97,7 +97,7 @@ Namespace 'invalid' not found."
 			expected_out="Using Kubernetes CLI.
 Namespace 'invalid' not found."
 		elif [ "x${cli}" != "xoc" ]; then
-			expected_out="Container platform CLI (e.g. kubectl, oc) not found."
+			expected_out="Unknown CLI '${cli}'."
 		fi
 		args="${args} -c ${cli}"
 	fi
@@ -152,6 +152,10 @@ testit "test namespace invalid" \
 
 testit "test namespace invalid kubectl" \
 	test_namespace_invalid kubectl \
+	|| failed=$((failed + 1))
+
+testit "test namespace invalid unknown-cli" \
+	test_namespace_invalid unknown-cli \
 	|| failed=$((failed + 1))
 
 testok $0 ${failed}

--- a/tests/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/gk-deploy/test_gk_deploy_basic.sh
@@ -18,7 +18,7 @@ source "${INC_DIR}/subunit.sh"
 
 test_missing_topology () {
 	${GK_DEPLOY} -y
-	if [ "x$?" = "x0" ]; then
+	if [[ "x$?" == "x0" ]]; then
 		echo "ERROR: gk_deploy without toplogoy succeeded"
 		return 1
 	fi
@@ -34,21 +34,21 @@ test_cli_not_found () {
 	OUT=$(${GK_DEPLOY} -y ${TOPOLOGY})
 	local rc=${?}
 
-	if [ "x${rc}" = "x0" ]; then
+	if [[ "x${rc}" == "x0" ]]; then
 		echo "ERROR: gk-deploy succeeded "\
 			"(output: \"${OUT}\")"
 		PATH=${saved_path}
 		return 1
 	fi
 
-	if [ "x${rc}" != "x1" ]; then
+	if [[ "x${rc}" != "x1" ]]; then
 		echo "ERROR: gk-deploy gave ${rc}, " \
 			"expected 1 (output: \"${OUT}\")"
 		PATH=${saved_path}
 		return 1
 	fi
 
-	if [ "${OUT}" != "${expected_out}" ]; then
+	if [[ "${OUT}" != "${expected_out}" ]]; then
 		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
 		PATH=${saved_path}
 		return 1
@@ -65,19 +65,19 @@ test_cli_unknown () {
 	OUT=$(${GK_DEPLOY} -y -c ${cli} ${TOPOLOGY})
 	local rc=$?
 
-	if [ "x${rc}" = "x0" ]; then
+	if [[ "x${rc}" == "x0" ]]; then
 		echo "ERROR: gk-deploy -c ${cli} succeeded "\
 			"(output: \"${OUT}\")"
 		return 1
 	fi
 
-	if [ "x${rc}" != "x1" ]; then
+	if [[ "x${rc}" != "x1" ]]; then
 		echo "ERROR: gk-deploy -c ${cli} gave ${rc}, " \
 			"expected 1 (output: \"${OUT}\")"
 		return 1
 	fi
 
-	if [ "${OUT}" != "${expected_out}" ]; then
+	if [[ "${OUT}" != "${expected_out}" ]]; then
 		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
 		return 1
 	fi
@@ -91,12 +91,12 @@ test_namespace_invalid () {
 	local expected_out="Using OpenShift CLI.
 Namespace 'invalid' not found."
 
-	if [ "x${#}" != "x0" ]; then
+	if [[ "x${#}" != "x0" ]]; then
 		cli="${1}"
-		if [ "x${cli}" = "xkubectl" ]; then
+		if [[ "x${cli}" == "xkubectl" ]]; then
 			expected_out="Using Kubernetes CLI.
 Namespace 'invalid' not found."
-		elif [ "x${cli}" != "xoc" ]; then
+		elif [[ "x${cli}" != "xoc" ]]; then
 			expected_out="Unknown CLI '${cli}'."
 		fi
 		args="${args} -c ${cli}"
@@ -108,19 +108,19 @@ Namespace 'invalid' not found."
 	echo "cmd: '${GK_DEPLOY} ${args} ${TOPOLOGY}'"
 	echo "out: '${OUT}'"
 
-	if [ "x${rc}" = "x0" ]; then
+	if [[ "x${rc}" == "x0" ]]; then
 		echo "ERROR: gk-deploy ${args} succeeded "\
 			"(output: \"${OUT}\")"
 		return 1
 	fi
 
-	if [ "x${rc}" != "x1" ]; then
+	if [[ "x${rc}" != "x1" ]]; then
 		echo "ERROR: gk-deploy ${args} gave ${rc}, " \
 			"expected 1 (output: \"${OUT}\")"
 		return 1
 	fi
 
-	if [ "${OUT}" != "${expected_out}" ]; then
+	if [[ "${OUT}" != "${expected_out}" ]]; then
 		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
 		return 1
 	fi

--- a/tests/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/gk-deploy/test_gk_deploy_basic.sh
@@ -28,7 +28,7 @@ test_missing_topology () {
 
 test_cli_not_found () {
 	local saved_path="${PATH}"
-	PATH="/usr/bin:/bin"
+	PATH="/doesnotexist"
 	local expected_out="Container platform CLI (e.g. kubectl, oc) not found."
 
 	OUT=$(${GK_DEPLOY} -y ${TOPOLOGY})
@@ -130,7 +130,7 @@ Namespace 'invalid' not found."
 
 failed=0
 
-testit "test missing toplogy" \
+testit "test missing topology" \
 	test_missing_topology \
 	|| failed=$((failed + 1))
 

--- a/tests/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/gk-deploy/test_gk_deploy_basic.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname ${0}); pwd)
+STUBS_DIR="${SCRIPT_DIR}/stubs"
+TESTS_DIR="${SCRIPT_DIR}/.."
+INC_DIR="${TESTS_DIR}/common"
+BASE_DIR="${SCRIPT_DIR}/../.."
+DEPLOY_DIR="${BASE_DIR}/deploy"
+
+GK_DEPLOY="${DEPLOY_DIR}/gk-deploy"
+TOPOLOGY="${DEPLOY_DIR}/topology.json.sample"
+
+PATH="${STUBS_DIR}:$PATH"
+
+source "${INC_DIR}/subunit.sh"
+
+
+
+test_missing_topology () {
+	${GK_DEPLOY} -y
+	if [ "x$?" = "x0" ]; then
+		echo "ERROR: gk_deploy without toplogoy succeeded"
+		return 1
+	fi
+
+	return 0
+}
+
+test_cli_not_found () {
+	local saved_path="${PATH}"
+	PATH="/usr/bin:/bin"
+	local expected_out="Container platform CLI (e.g. kubectl, oc) not found."
+
+	OUT=$(${GK_DEPLOY} -y ${TOPOLOGY})
+	local rc=${?}
+
+	if [ "x${rc}" = "x0" ]; then
+		echo "ERROR: gk-deploy succeeded "\
+			"(output: \"${OUT}\")"
+		PATH=${saved_path}
+		return 1
+	fi
+
+	if [ "x${rc}" != "x1" ]; then
+		echo "ERROR: gk-deploy gave ${rc}, " \
+			"expected 1 (output: \"${OUT}\")"
+		PATH=${saved_path}
+		return 1
+	fi
+
+	if [ "${OUT}" != "${expected_out}" ]; then
+		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
+		PATH=${saved_path}
+		return 1
+	fi
+
+	return 0
+
+}
+
+test_cli_unknown () {
+	local cli="${1}"
+	local expected_out="Unknown CLI '${cli}'."
+
+	OUT=$(${GK_DEPLOY} -y -c ${cli} ${TOPOLOGY})
+	local rc=$?
+
+	if [ "x${rc}" = "x0" ]; then
+		echo "ERROR: gk-deploy -c ${cli} succeeded "\
+			"(output: \"${OUT}\")"
+		return 1
+	fi
+
+	if [ "x${rc}" != "x1" ]; then
+		echo "ERROR: gk-deploy -c ${cli} gave ${rc}, " \
+			"expected 1 (output: \"${OUT}\")"
+		return 1
+	fi
+
+	if [ "${OUT}" != "${expected_out}" ]; then
+		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
+		return 1
+	fi
+
+	return 0
+}
+
+test_namespace_invalid () {
+	local cli=""
+	local args="-y -n invalid"
+	local expected_out="Using OpenShift CLI.
+Namespace 'invalid' not found."
+
+	if [ "x${#}" != "x0" ]; then
+		cli="${1}"
+		if [ "x${cli}" = "xkubectl" ]; then
+			expected_out="Using Kubernetes CLI.
+Namespace 'invalid' not found."
+		elif [ "x${cli}" != "xoc" ]; then
+			expected_out="Container platform CLI (e.g. kubectl, oc) not found."
+		fi
+		args="${args} -c ${cli}"
+	fi
+
+	OUT=$(${GK_DEPLOY} ${args} ${TOPOLOGY})
+	local rc=$?
+
+	echo "cmd: '${GK_DEPLOY} ${args} ${TOPOLOGY}'"
+	echo "out: '${OUT}'"
+
+	if [ "x${rc}" = "x0" ]; then
+		echo "ERROR: gk-deploy ${args} succeeded "\
+			"(output: \"${OUT}\")"
+		return 1
+	fi
+
+	if [ "x${rc}" != "x1" ]; then
+		echo "ERROR: gk-deploy ${args} gave ${rc}, " \
+			"expected 1 (output: \"${OUT}\")"
+		return 1
+	fi
+
+	if [ "${OUT}" != "${expected_out}" ]; then
+		echo "ERROR: got output '${OUT}', expected '${expected_out}'"
+		return 1
+	fi
+
+	return 0
+}
+
+failed=0
+
+testit "test missing toplogy" \
+	test_missing_topology \
+	|| failed=$((failed + 1))
+
+testit "test cli not found" \
+	test_cli_not_found \
+	|| failed=$((failed + 1))
+
+testit "test cli does not exist" \
+	test_cli_unknown doesnotexist \
+	|| failed=$((failed + 1))
+
+testit "test cli unknown" \
+	test_cli_unknown /usr/bin/true \
+	|| failed=$((failed + 1))
+
+testit "test namespace invalid" \
+	test_namespace_invalid \
+	|| failed=$((failed + 1))
+
+testit "test namespace invalid kubectl" \
+	test_namespace_invalid kubectl \
+	|| failed=$((failed + 1))
+
+testok $0 ${failed}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+for testdir in ${SCRIPT_DIR}/*; do
+	if [ ! -d ${testdir} ]; then
+		continue
+	fi
+
+	if [ ! -x ${testdir}/run.sh ]; then
+		continue
+	fi
+
+	pushd ${testdir}
+	./run.sh
+	rc=$?
+	popd
+
+	if [ ${rc} -ne 0 ]; then
+		exit 1
+	fi
+done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3,11 +3,11 @@
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 for testdir in ${SCRIPT_DIR}/*; do
-	if [ ! -d ${testdir} ]; then
+	if [[ ! -d ${testdir} ]]; then
 		continue
 	fi
 
-	if [ ! -x ${testdir}/run.sh ]; then
+	if [[ ! -x ${testdir}/run.sh ]]; then
 		continue
 	fi
 
@@ -16,7 +16,7 @@ for testdir in ${SCRIPT_DIR}/*; do
 	rc=$?
 	popd
 
-	if [ ${rc} -ne 0 ]; then
+	if [[ ${rc} -ne 0 ]]; then
 		exit 1
 	fi
 done

--- a/tests/yaml/glusterfs-daemonset-wrong.yaml
+++ b/tests/yaml/glusterfs-daemonset-wrong.yaml
@@ -1,0 +1,177 @@
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: glusterfs
+  labels:
+    glusterfs: daemonset
+  annotations:
+    description: GlusterFS DaemonSet
+    tags: glusterfs
+    metadata:
+      name: glusterfs
+      labels:
+        glusterfs-node: pod
+    spec:
+      nodeSelector:
+        storagenode: glusterfs
+      hostNetwork: true
+      containers:
+      - image: gluster/gluster-centos:latest
+        imagePullPolicy: IfNotPresent
+        name: glusterfs
+        volumeMounts:
+        - name: glusterfs-heketi
+          mountPath: "/var/lib/heketi"
+        - name: glusterfs-run
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: glusterfs
+  labels:
+    glusterfs: daemonset
+  annotations:
+    description: GlusterFS DaemonSet
+    tags: glusterfs
+    metadata:
+      name: glusterfs
+      labels:
+        glusterfs-node: pod
+    spec:
+      nodeSelector:
+        storagenode: glusterfs
+      hostNetwork: true
+      containers:
+      - image: gluster/gluster-centos:latest
+        imagePullPolicy: IfNotPresent
+        name: glusterfs
+        volumeMounts:
+        - name: glusterfs-heketi
+          mountPath: "/var/lib/heketi"
+        - name: glusterfs-run
+          mountPath: "/run"
+        - name: glusterfs-lvm
+          mountPath: "/run/lvm"
+        - name: glusterfs-etc
+          mountPath: "/etc/glusterfs"
+        - name: glusterfs-logs
+          mountPath: "/var/log/glusterfs"
+        - name: glusterfs-config
+          mountPath: "/var/lib/glusterd"
+        - name: glusterfs-dev
+          mountPath: "/dev"
+        - name: glusterfs-misc
+          mountPath: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-cgroup
+          mountPath: "/sys/fs/cgroup"
+          readOnly: true
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+        livenessProbe:
+          timeoutSeconds: 3
+          initialDelaySeconds: 60
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+      volumes:
+      - name: glusterfs-heketi
+        hostPath:
+          path: "/var/lib/heketi"
+      - name: glusterfs-run
+      - name: glusterfs-lvm
+        hostPath:
+          path: "/run/lvm"
+      - name: glusterfs-etc
+        hostPath:
+          path: "/etc/glusterfs"
+      - name: glusterfs-logs
+        hostPath:
+          path: "/var/log/glusterfs"
+      - name: glusterfs-config
+        hostPath:
+          path: "/var/lib/glusterd"
+      - name: glusterfs-dev
+        hostPath:
+          path: "/dev"
+      - name: glusterfs-misc
+        hostPath:
+          path: "/var/lib/misc/glusterfsd"
+      - name: glusterfs-cgroup
+        hostPath:
+          path: "/sys/fs/cgroup"
+      - name: glusterfs-ssl
+        hostPath:
+          path: "/etc/ssl"
+
+          mountPath: "/run"
+        - name: glusterfs-lvm
+          mountPath: "/run/lvm"
+        - name: glusterfs-etc
+          mountPath: "/etc/glusterfs"
+        - name: glusterfs-logs
+          mountPath: "/var/log/glusterfs"
+        - name: glusterfs-config
+          mountPath: "/var/lib/glusterd"
+        - name: glusterfs-dev
+          mountPath: "/dev"
+        - name: glusterfs-misc
+          mountPath: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-cgroup
+          mountPath: "/sys/fs/cgroup"
+          readOnly: true
+        - name: glusterfs-ssl
+          mountPath: "/etc/ssl"
+          readOnly: true
+        securityContext:
+          capabilities: {}
+          privileged: true
+        readinessProbe:
+          timeoutSeconds: 3
+          initialDelaySeconds: 60
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+        livenessProbe:
+          timeoutSeconds: 3
+          initialDelaySeconds: 60
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - systemctl status glusterd.service
+      volumes:
+      - name: glusterfs-heketi
+        hostPath:
+          path: "/var/lib/heketi"
+      - name: glusterfs-run
+      - name: glusterfs-lvm
+        hostPath:
+          path: "/run/lvm"
+      - name: glusterfs-etc
+        hostPath:
+          path: "/etc/glusterfs"
+      - name: glusterfs-logs
+        hostPath:
+          path: "/var/log/glusterfs"
+      - name: glusterfs-config
+        hostPath:
+          path: "/var/lib/glusterd"
+      - name: glusterfs-dev
+        hostPath:
+          path: "/dev"
+      - name: glusterfs-misc
+        hostPath:
+          path: "/var/lib/misc/glusterfsd"
+      - name: glusterfs-cgroup
+        hostPath:
+          path: "/sys/fs/cgroup"
+      - name: glusterfs-ssl
+        hostPath:
+          path: "/etc/ssl"

--- a/tests/yaml/run.sh
+++ b/tests/yaml/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+echo "running tests in ${SCRIPT_DIR}"
+
+for test in ${SCRIPT_DIR}/test_*.sh ; do
+	$test
+done

--- a/tests/yaml/test_syntax.sh
+++ b/tests/yaml/test_syntax.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd $(dirname ${0}); pwd)
+TESTS_DIR="${SCRIPT_DIR}/.."
+INC_DIR="${TESTS_DIR}/common"
+BASE_DIR="${SCRIPT_DIR}/../.."
+DEPLOY_DIR="${BASE_DIR}/deploy"
+KTD="${DEPLOY_DIR}/kube-templates"
+OTD="${DEPLOY_DIR}/ocp-templates"
+
+KGDY="${KTD}/glusterfs-daemonset.yaml"
+KHDY="${KTD}/heketi-deployment.yaml"
+KHSY="${KTD}/heketi-service-account.yaml"
+OGTY="${OTD}/glusterfs-template.yaml"
+OHTY="${OTD}/heketi-template.yaml"
+OHSY="${OTD}/heketi-service-account.yaml"
+
+FAULTY_YAML="${SCRIPT_DIR}/glusterfs-daemonset-wrong.yaml"
+
+source "${INC_DIR}/subunit.sh"
+
+check_yaml () {
+	local yaml=${1}
+	yamllint -f parsable -d relaxed ${yaml}
+}
+
+check_invalid_yaml () {
+	check_yaml ${1}
+	if [ "x$?" = "x0" ]; then
+		echo "ERROR: parsing invalid yaml succeeded"
+		return 1
+	fi
+
+	return 0
+}
+
+failed=0
+
+testit "check invalid yaml" \
+	check_invalid_yaml ${FAULTY_YAML} \
+	|| failed=$((failed + 1))
+
+for yaml in ${KGDY} ${KHDY} ${KHSY} ${OGTY} ${OHTY} ${OHSY} ; do
+	testit "check $(basename ${yaml})" \
+		check_yaml ${yaml} \
+		|| failed=$((failed + 1))
+done
+
+testok $0 ${failed}

--- a/tests/yaml/test_syntax.sh
+++ b/tests/yaml/test_syntax.sh
@@ -28,7 +28,7 @@ check_yaml () {
 
 check_invalid_yaml () {
 	check_yaml ${1}
-	if [ "x$?" = "x0" ]; then
+	if [[ "x$?" == "x0" ]]; then
 		echo "ERROR: parsing invalid yaml succeeded"
 		return 1
 	fi

--- a/tests/yaml/test_syntax.sh
+++ b/tests/yaml/test_syntax.sh
@@ -11,9 +11,11 @@ OTD="${DEPLOY_DIR}/ocp-templates"
 KGDY="${KTD}/glusterfs-daemonset.yaml"
 KHDY="${KTD}/heketi-deployment.yaml"
 KHSY="${KTD}/heketi-service-account.yaml"
+KDHY="${KTD}/deploy-heketi-deployment.yaml"
 OGTY="${OTD}/glusterfs-template.yaml"
 OHTY="${OTD}/heketi-template.yaml"
 OHSY="${OTD}/heketi-service-account.yaml"
+ODHY="${OTD}/deploy-heketi-template.yaml"
 
 FAULTY_YAML="${SCRIPT_DIR}/glusterfs-daemonset-wrong.yaml"
 
@@ -40,7 +42,7 @@ testit "check invalid yaml" \
 	check_invalid_yaml ${FAULTY_YAML} \
 	|| failed=$((failed + 1))
 
-for yaml in ${KGDY} ${KHDY} ${KHSY} ${OGTY} ${OHTY} ${OHSY} ; do
+for yaml in ${KGDY} ${KHDY} ${KHSY} ${KDHY} ${OGTY} ${OHTY} ${OHSY} ${ODHY} ; do
 	testit "check $(basename ${yaml})" \
 		check_yaml ${yaml} \
 		|| failed=$((failed + 1))


### PR DESCRIPTION
This is based on the original ideas of @MohamedAshiqrh 's PR #184 .
I basically took (and slightly) extended the kinds of commands that are run,
but put it into more of a test framework. (Copied the tiny "subunit.sh" from samba).
So now it really fails when a test fails. Also integrated this into "make test" and into .travis.yml.

I am pushing this to get some comments.
It currently contains the patches of PR #193 as well.
If we agree that this is the way to go, and if we merge #193, then I'd rebase once more to make git log clean.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/194)
<!-- Reviewable:end -->
