### PR TITLE
QOS: adding Memory limitaion for the gluster pod

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -22,6 +22,11 @@ spec:
       - image: gluster/gluster-centos:latest
         imagePullPolicy: IfNotPresent
         name: glusterfs
+        resources:
+          requests:
+            memory: 20Gi
+          limits:
+            memory: 32Gi
         volumeMounts:
         - name: glusterfs-heketi
           mountPath: "/var/lib/heketi"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -35,6 +35,11 @@ objects:
         - image: gluster/gluster-centos:latest
           imagePullPolicy: IfNotPresent
           name: glusterfs
+          resources:
+            requests:
+              memory: 20Gi
+            limits:
+              memory: 32Gi
           volumeMounts:
           - name: glusterfs-heketi
             mountPath: "/var/lib/heketi"
@@ -83,7 +88,6 @@ objects:
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 15
-          resources: {}
           terminationMessagePath: "/dev/termination-log"
         volumes:
         - name: glusterfs-heketi


### PR DESCRIPTION
A Guaranteed memory container gets the amount of memory requested,
but no more. In the event of an out of memory event, it will only
be killed at last on the system.

Signed-off-by: Mohamed Ashiq Liyazudeen <mliyazud@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/214)
<!-- Reviewable:end -->
