### PR TITLE
vagrant: give firewalld rules names for easier stepping/tracking

### DIFF
--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -55,25 +55,32 @@
   service: name=firewalld state=started enabled=yes
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-interface=eth1`
-- firewalld: zone=trusted interface=eth1 permanent=true state=enabled immediate=true
+- name: firewall trust eth1
+  firewalld: zone=trusted interface=eth1 permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-interface=weave`
-- firewalld: zone=trusted interface=weave permanent=true state=enabled immediate=true
+- name: firewall trust weave
+  firewalld: zone=trusted interface=weave permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-source=172.42.42.0/24`
-- firewalld: source=172.42.42.0/24 zone=trusted permanent=true state=enabled immediate=true
+- name: firewall trust 172.42.42.0/24
+  firewalld: source=172.42.42.0/24 zone=trusted permanent=true state=enabled immediate=true
 
 # 10.32.0.0/12 is the default pod CIDR for Weave Net
 # you will need to update this if you are using a different
 # network provider, or a different CIDR for whatever reason
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-source=10.32.0.0/12`
-- firewalld: source=10.32.0.0/12 zone=trusted permanent=true state=enabled immediate=true
+- name: firewall trust weave net CIDR
+  firewalld: source=10.32.0.0/12 zone=trusted permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=10250`
-- firewalld: port=10250/tcp zone=trusted permanent=true state=enabled immediate=true
+- name: firewall trust port 10250
+  firewalld: port=10250/tcp zone=trusted permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=9898`
-- firewalld: port=6443/tcp zone=trusted permanent=true state=enabled immediate=true
+- name: firewall trust port 6443
+  firewalld: port=6443/tcp zone=trusted permanent=true state=enabled immediate=true
 
 # Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=9898`
-- firewalld: port=9898/tcp zone=trusted permanent=true state=enabled immediate=true
+- name: firewall trust port 9898
+  firewalld: port=9898/tcp zone=trusted permanent=true state=enabled immediate=true

--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -54,33 +54,26 @@
 - name: Ensure firewalld.service
   service: name=firewalld state=started enabled=yes
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-interface=eth1`
 - name: firewall trust eth1
   firewalld: zone=trusted interface=eth1 permanent=true state=enabled immediate=true
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-interface=weave`
 - name: firewall trust weave
   firewalld: zone=trusted interface=weave permanent=true state=enabled immediate=true
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-source=172.42.42.0/24`
 - name: firewall trust 172.42.42.0/24
   firewalld: source=172.42.42.0/24 zone=trusted permanent=true state=enabled immediate=true
 
 # 10.32.0.0/12 is the default pod CIDR for Weave Net
 # you will need to update this if you are using a different
 # network provider, or a different CIDR for whatever reason
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-source=10.32.0.0/12`
 - name: firewall trust weave net CIDR
   firewalld: source=10.32.0.0/12 zone=trusted permanent=true state=enabled immediate=true
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=10250`
 - name: firewall trust port 10250
   firewalld: port=10250/tcp zone=trusted permanent=true state=enabled immediate=true
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=9898`
 - name: firewall trust port 6443
   firewalld: port=6443/tcp zone=trusted permanent=true state=enabled immediate=true
 
-# Equivalent of `firewall-cmd --permanent --zone=trusted --add-port=9898`
 - name: firewall trust port 9898
   firewalld: port=9898/tcp zone=trusted permanent=true state=enabled immediate=true


### PR DESCRIPTION
Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/224)
<!-- Reviewable:end -->
