### PR TITLE
test: add first functional tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
     - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
     packages:
     - shellcheck
-    - realpath
 
 before_install:
 - sudo pip install yamllint

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,3 +3,5 @@
 This contains the tests for gluster-kubernetes.
 * The subdirectory `simple` contains simple local tests
 like syntax-checks, unit tests and test that use mocking and stubbing.
+* The subdirectory `complex` contains end-to-end functional tests
+run in vagrant environments.

--- a/tests/complex/README.md
+++ b/tests/complex/README.md
@@ -1,0 +1,42 @@
+# Test suite - complex tests for gluster-kubernetes
+
+These tests are complex, end-to-end functional tests using
+our vagrant based test environment.
+
+## Running
+
+`./run.sh` will run all the tests. But the tests
+can also be run individually like
+
+```
+./test-setup.sh
+./test-gk-deploy.sh
+```
+
+and at a later time:
+
+```
+./test-dynamic-provisioning.sh
+```
+
+## Environment variables
+
+There are various environment variables that can be
+overridden, so that this can run for instance against
+a different vagrant environment. E.g. if you have
+already brought up a vagrant environment manually,
+you could from the vagrant-dir do:
+
+```
+export VAGRANT_DIR=$(realpath ./)
+../tests/functional/test-gk-deploy.sh
+```
+
+All variables:
+- `BASE_DIR`
+- `TEST_DIR`
+- `DEPLOY_DIR`
+- `VAGRANT_DIR`
+- `TOPOLOGY_FILE`
+
+If you override these, then you should provide absolute paths.

--- a/tests/complex/lib.sh
+++ b/tests/complex/lib.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# honor variables set from the caller:
+: ${TEST_DIR:="$(realpath $(dirname $0))"}
+: ${BASE_DIR:="${TEST_DIR}/../.."}
+: ${VAGRANT_DIR:="${BASE_DIR}/vagrant"}
+: ${DEPLOY_DIR:="${BASE_DIR}/deploy"}
+: ${TOPOLOGY_FILE:="${DEPLOY_DIR}/topology.json.sample"}
+: ${TESTNAME:="$(basename $0)"}
+
+SSH_CONFIG=${VAGRANT_DIR}/ssh-config
+
+pass() {
+	if [[ "x${TESTNAME}" != "x" ]]; then
+		echo "PASS: ${TESTNAME}"
+	else
+		echo "PASS"
+	fi
+
+	exit 0
+}
+
+fail() {
+	# print an additional message if given
+	if [[ $# -ge 1 ]]; then
+		echo "$*"
+	fi
+
+	if [[ "x${TESTNAME}" != "x" ]]; then
+		echo "FAIL: ${TESTNAME}"
+	else
+		echo "FAIL"
+	fi
+
+	exit 1
+}
+
+create_vagrant() {
+	cd ${VAGRANT_DIR}
+	./up.sh
+}
+
+start_vagrant() {
+	cd ${VAGRANT_DIR}
+	vagrant up --no-provision
+}
+
+stop_vagrant() {
+	cd ${VAGRANT_DIR}
+	vagrant halt
+}
+
+destroy_vagrant() {
+	cd ${VAGRANT_DIR}
+	vagrant destroy
+}
+
+ssh_config() {
+	cd ${VAGRANT_DIR}
+	vagrant ssh-config > ${SSH_CONFIG}
+}
+
+copy_deploy() {
+	cd ${VAGRANT_DIR}
+	ssh -F "${SSH_CONFIG}" master "mkdir -p ~/deploy"
+	scp -r -F "${SSH_CONFIG}" "${DEPLOY_DIR}/"* master:~/deploy
+	scp    -F "${SSH_CONFIG}" "${TOPOLOGY_FILE}" master:~/deploy/topology.json
+}
+
+pull_docker_image() {
+	local image=$1
+	cd ${VAGRANT_DIR}
+	for NODE in node0 node1 node2 ; do
+		ssh -F ${SSH_CONFIG} ${NODE} "sudo docker pull ${image}"
+	done
+}
+
+run_on_node() {
+	script=$(realpath $1)
+	shift
+	node=$1
+	shift
+
+	cd ${VAGRANT_DIR}
+
+	scp -F "${SSH_CONFIG}" "${script}" "${node}":
+	ssh -t -F "${SSH_CONFIG}" "${node}" "./$(basename ${script})"
+}

--- a/tests/complex/run.sh
+++ b/tests/complex/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+TEST_DIR="$(realpath $(dirname $0))"
+LIB_DIR="${TEST_DIR}"
+TESTNAME=""
+
+source "${LIB_DIR}/lib.sh"
+
+${TEST_DIR}/test-setup.sh || fail
+
+${TEST_DIR}/test-gk-deploy.sh || fail
+
+${TEST_DIR}/test-dynamic-provisioning.sh || fail
+
+${TEST_DIR}/test-teardown.sh || fail
+
+pass

--- a/tests/complex/test-dynamic-provisioning.sh
+++ b/tests/complex/test-dynamic-provisioning.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+TEST_DIR="$(realpath $(dirname $0))"
+LIB_DIR="${TEST_DIR}"
+
+DOCKER_IMAGE="gcr.io/google_containers/nginx-slim:0.8"
+
+source "${LIB_DIR}/lib.sh"
+
+ssh_config || fail "ERROR creating ssh config"
+
+pull_docker_image "${DOCKER_IMAGE}" || fail "ERROR pulling nginx docker images"
+
+run_on_node "${TEST_DIR}/test-inside-dynamic-provisioning.sh" master || fail
+
+pass

--- a/tests/complex/test-gk-deploy.sh
+++ b/tests/complex/test-gk-deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TEST_DIR="$(realpath $(dirname $0))"
+LIB_DIR="${TEST_DIR}"
+
+source "${LIB_DIR}/lib.sh"
+
+ssh_config || fail "ERROR to creating ssh-config"
+
+copy_deploy || fail "ERROR copying deployment files"
+
+run_on_node "${TEST_DIR}/test-inside-gk-deploy.sh" master || fail
+
+pass

--- a/tests/complex/test-inside-dynamic-provisioning.sh
+++ b/tests/complex/test-inside-dynamic-provisioning.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# test dynamic provisioning
+
+HEKETI_CLI_SERVER=$(kubectl get svc/heketi --template 'http://{{.spec.clusterIP}}:{{(index .spec.ports 0).port}}')
+export HEKETI_CLI_SERVER
+
+
+# SC
+
+SC="mysc"
+
+cat > "${SC}.yaml" <<EOF
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: ${SC}
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "${HEKETI_CLI_SERVER}"
+EOF
+
+echo "creating a storage class"
+kubectl create -f "./${SC}.yaml"
+
+#TODO: check existence of sc
+kubectl get storageclass
+
+
+# PVC
+
+PVC="mypvc"
+
+cat > "${PVC}.yaml" <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: ${PVC}
+ annotations:
+   volume.beta.kubernetes.io/storage-class: ${SC}
+spec:
+ accessModes:
+  - ReadWriteMany
+ resources:
+   requests:
+     storage: 2Gi
+EOF
+
+echo "creating a PVC"
+kubectl create -f "./${PVC}.yaml"
+
+
+echo "verifying the pvc has been created and bound"
+PVCstatus=$(kubectl get pvc | grep "${PVC}" | awk '{print $2}')
+while [[ "$PVCstatus" != 'Bound' ]] ; do
+	sleep 1
+	PVCstatus=$(kubectl get pvc | grep "${PVC}" | awk '{print $2}')
+done
+
+
+# APP
+
+APP="myapp"
+
+cat > "${APP}.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${APP}
+  labels:
+    name: ${APP}
+spec:
+  containers:
+  - name: ${APP}
+    image: gcr.io/google_containers/nginx-slim:0.8
+    ports:
+    - name: web
+      containerPort: 80
+    volumeMounts:
+    - name: mypv
+      mountPath: /usr/share/nginx/html
+  volumes:
+  - name: mypv
+    persistentVolumeClaim:
+      claimName: ${PVC}
+EOF
+
+echo "creating an app for using the PVC"
+kubectl create -f "${APP}.yaml"
+
+# wait for the app to be created and have an IP
+
+echo "waiting for app pod to become available"
+appIP=$(kubectl get pods -o wide | grep "${APP}" | awk '{print $6}')
+while [[ "$appIP" == '<none>' ]] ; do
+	sleep 1
+	appIP=$(kubectl get pods -o wide | grep "${APP}" | awk '{print $6}')
+done
+
+
+echo "putting content into application"
+CONTENT="Does this work? Yes! Great!!!"
+kubectl exec "${APP}" -- /bin/bash -c "echo \"${CONTENT}\" > /usr/share/nginx/html/index.html"
+
+
+echo "verifying we get back our content from the app"
+OUTPUT="$(curl http://${appIP})"
+
+if [[ "${OUTPUT}" != "${CONTENT}" ]]; then
+	echo "ERROR: did not get expected output from nginx pod"
+	exit 1
+fi
+
+
+echo "verifying the content is actually stored on gluster"
+mountinfo=$(kubectl exec "${APP}" -- /bin/bash -c "cat /proc/mounts | grep nginx" | awk '{print $1}')
+volname=$(echo -n ${mountinfo} | cut -d: -f2)
+glusterip=$(echo -n ${mountinfo} |cut -d: -f1)
+glusterpod=$(kubectl get pods -o wide | grep ${glusterip} | awk '{print $1}')
+
+brickinfopath="/var/lib/glusterd/vols/${volname}/bricks"
+brickinfofile=$(kubectl exec "${glusterpod}" -- /bin/bash -c "ls -1 ${brickinfopath} | head -n 1")
+brickpath=$(kubectl exec ${glusterpod} -- /bin/bash -c "cat ${brickinfopath}/${brickinfofile} | grep real_path | cut -d= -f2")
+brickhost=$(kubectl exec ${glusterpod} -- /bin/bash -c "cat ${brickinfopath}/${brickinfofile} | grep hostname | cut -d= -f2")
+brickpod=$(kubectl get pods -o wide | grep ${brickhost} | awk '{print $1}')
+
+BRICK_CONTENT=$(kubectl exec ${brickpod} -- /bin/bash -c "cat ${brickpath}/index.html")
+if [[ "${BRICK_CONTENT}" != "${CONTENT}" ]]; then
+	echo "ERROR: did not get expected content from brick"
+	exit 1
+fi
+
+echo "cleaning up"
+kubectl delete pod "${APP}"
+kubectl delete pvc "${PVC}"
+kubectl delete storageclass "${SC}"
+
+exit 0

--- a/tests/complex/test-inside-gk-deploy.sh
+++ b/tests/complex/test-inside-gk-deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# test gk-deploy
+
+cd ~/deploy
+
+num_gluster_pods_before=$(kubectl get pods | grep -s "glusterfs-" | wc -l)
+num_heketi_pods_before=$(kubectl get pods | grep -s "heketi-" | wc -l)
+
+./gk-deploy -y -g -n default ./topology.json
+
+if [[ $? -ne 0 ]]; then
+	echo "ERROR: gk-deploy failed"
+	exit 1
+fi
+
+# wait briefly for pods to settle down...
+sleep 2
+
+num_gluster_pods_after=$(kubectl get pods | grep -s "glusterfs-" | wc -l)
+num_heketi_pods_after=$(kubectl get pods | grep -s "heketi-" | grep -vs "deploy-heketi" | wc -l)
+
+if (( num_heketi_pods_after - num_heketi_pods_before != 1 )); then
+	echo "ERROR: unexpected number of heketi pods: " \
+		"${num_heketi_pods_after} - " \
+		"expected $(( num_heketi_pods_before + 1 ))"
+	exit 1
+fi
+
+if (( num_gluster_pods_after - num_gluster_pods_before != 3 )); then
+	echo "ERROR: unexpected number of gluster pods: " \
+		"${num_gluster_pods_after} - " \
+		"expected $(( num_gluster_pods_before + 3 ))"
+	exit 1
+fi
+
+echo "PASS"
+exit 0

--- a/tests/complex/test-setup.sh
+++ b/tests/complex/test-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TEST_DIR="$(realpath $(dirname $0))"
+LIB_DIR="${TEST_DIR}"
+
+source "${LIB_DIR}/lib.sh"
+
+create_vagrant || fail "ERROR creating vagrant environment"
+
+ssh_config || fail "ERROR creating ssh-config"
+
+pass

--- a/tests/complex/test-teardown.sh
+++ b/tests/complex/test-teardown.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+TEST_DIR="$(realpath $(dirname $0))"
+LIB_DIR="${TEST_DIR}"
+
+source "${LIB_DIR}/lib.sh"
+
+destroy_vagrant
+if [[ $? -ne 0 ]]; then
+	fail
+fi
+
+pass

--- a/tests/simple/gk-deploy/run.sh
+++ b/tests/simple/gk-deploy/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname $0))
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 echo "running tests in ${SCRIPT_DIR}"
 

--- a/tests/simple/gk-deploy/stubs/kubectl
+++ b/tests/simple/gk-deploy/stubs/kubectl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname $0))
+SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 
 if [[ "x$1" == "xget" ]]; then
 	if [[ "x$2" != "xnamespaces" ]]; then

--- a/tests/simple/gk-deploy/stubs/oc
+++ b/tests/simple/gk-deploy/stubs/oc
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname $0))
+SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 
 if [[ "x$1" == "xget" ]]; then
 	if [[ "x$2" != "xnamespaces" ]]; then

--- a/tests/simple/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/simple/gk-deploy/test_gk_deploy_basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname ${0}))
+SCRIPT_DIR=$(cd $(dirname ${0}); pwd)
 STUBS_DIR="${SCRIPT_DIR}/stubs"
 TESTS_DIR="${SCRIPT_DIR}/.."
 INC_DIR="${TESTS_DIR}/common"

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname $0))
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 for testdir in ${SCRIPT_DIR}/*; do
 	if [[ ! -d ${testdir} ]]; then

--- a/tests/simple/yaml/run.sh
+++ b/tests/simple/yaml/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname $0))
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 echo "running tests in ${SCRIPT_DIR}"
 

--- a/tests/simple/yaml/test_syntax.sh
+++ b/tests/simple/yaml/test_syntax.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(realpath $(dirname ${0}))
+SCRIPT_DIR=$(cd $(dirname ${0}); pwd)
 TESTS_DIR="${SCRIPT_DIR}/.."
 INC_DIR="${TESTS_DIR}/common"
 BASE_DIR="${SCRIPT_DIR}/../../.."


### PR DESCRIPTION
These functional tests basically run the steps of the
quickstart guide and the dynamic provisioning example.

./run.sh will bring up vagrant, run all tests and will
destroy the vagrant environment again.

Tests can also be run individually against an already
running vagrant environment:

./test-gk-deploy.sh
./test-dynamic-provisioning.sh

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/225)
<!-- Reviewable:end -->
