### PR TITLE
vagrant: fix kubeadm init call

### DIFF
--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: kubeadm init
-  command: kubeadm init --token={{ kubernetes_token }} --use-kubernetes-version=v{{ kubernetes_version }}  --api-advertise-addresses={{ ansible_eth1.ipv4.address }}
+  command: kubeadm init --token={{ kubernetes_token }} --kubernetes-version=v{{ kubernetes_version }}  --api-advertise-addresses={{ ansible_eth1.ipv4.address }}
 
 - name: Set --cluster-cidr flag in kube-proxy daemonset (workaround for https://github.com/kubernetes/kubernetes/issues/34101)
   shell: kubectl -n kube-system get ds -l 'component=kube-proxy' -o json | sed '/"--kubeconfig=\/run\/kubeconfig"/ s/$/,\n"--cluster-cidr=10.32.0.0\/12"/' | kubectl apply -f - && kubectl -n kube-system delete pods -l 'component=kube-proxy'


### PR DESCRIPTION
this adapts for the change of:

https://github.com/kubernetes/kubernetes/pull/41820

renamed --use-kubernetes-version to --kubernetes-version

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/226)
<!-- Reviewable:end -->
