### PR TITLE
don't delete a secret that we don't create

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -153,7 +153,6 @@ abort() {
   else
     eval_output "${CLI} delete deployment heketi 2>&1"
   fi
-  eval_output "${CLI} delete secret heketi-db-backup 2>&1"
   if [[ ${GLUSTER} -eq 1 ]]; then
     while read -r node; do
       debug "Removing label from '${node}' as a GlusterFS node."


### PR DESCRIPTION
gk-deploy does not setup heketi with db backed up to secrets, hence it
is not right that we delete the secrets for the same.

Closes: #231

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/232)
<!-- Reviewable:end -->
