### PR TITLE
Properly wait for heketi URL

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -492,13 +492,15 @@ output "OK"
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
-  heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
-  if [[ "${heketi_service}" != "<none>" ]] && [[ "${CLI}" == *oc\ * ]]; then
-      heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
   fi
   sleep 1
+  heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
 done
 debug "OK"
+
+if [[ "${CLI}" == *oc\ * ]]; then
+  heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
+fi
 
 hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
@@ -554,13 +556,14 @@ output "OK"
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
-  heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
-  if [[ "${heketi_service}" != "<none>" ]] && [[ "${CLI}" == *oc\ * ]]; then
-      heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
-  fi
   sleep 1
+  heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 debug "OK"
+
+if [[ "${CLI}" == *oc\ * ]]; then
+  heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
+fi
 
 hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -489,14 +489,18 @@ if [[ $? -ne 0 ]]; then
 fi
 output "OK"
 
+s=0
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
+  if [[ ${s} -ge ${WAIT} ]]; then
+    debug "Timed out waiting for deploy-heketi service."
+    break
   fi
   sleep 1
+  ((s+=1))
   heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
 done
-debug "OK"
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
@@ -509,6 +513,8 @@ if [[ "${hello}" != "Hello from Heketi" ]]; then
     output "Please verify that a router has been properly configured."
   fi
   abort
+else
+  debug "OK"
 fi
 
 load_temp=$(mktemp)
@@ -553,13 +559,18 @@ output -n "Waiting for heketi pod to start ... "
 check_pods "glusterfs=heketi-pod"
 output "OK"
 
+s=0
 heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
+  if [[ ${s} -ge ${WAIT} ]]; then
+    debug "Timed out waiting for heketi service."
+    break
+  fi
   sleep 1
+  ((s+=1))
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
-debug "OK"
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
@@ -573,6 +584,7 @@ if [[ "${hello}" != "Hello from Heketi" ]]; then
   fi
   exit 1
 else
+  debug "OK"
   output "heketi is now running."
 fi
 

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -493,6 +493,9 @@ heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
   heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
+  if [[ "${heketi_service}" != "<none>" ]] && [[ "${CLI}" == *oc\ * ]]; then
+      heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
+  fi
   sleep 1
 done
 debug "OK"
@@ -500,6 +503,9 @@ debug "OK"
 hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
   output "Failed to communicate with deploy-heketi service."
+  if [[ "${CLI}" == *oc\ * ]]; then
+    output "Please verify that a router has been properly configured."
+  fi
   abort
 fi
 
@@ -549,13 +555,19 @@ heketi_service=""
 debug -n "Determining heketi service URL ... "
 while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
+  if [[ "${heketi_service}" != "<none>" ]] && [[ "${CLI}" == *oc\ * ]]; then
+      heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
+  fi
   sleep 1
 done
 debug "OK"
 
 hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
-  output "Failed to communicate with heketi service.\nVerify that service and endpoints configured properly."
+  output "Failed to communicate with heketi service."
+  if [[ "${CLI}" == *oc\ * ]]; then
+    output "Please verify that a router has been properly configured."
+  fi
   exit 1
 else
   output "heketi is now running."


### PR DESCRIPTION
PR #230 took away the ability to run gk-deploy outside the cluster for OpenShift deployments by removing the ability to use a route when determining the heketi URL. This PR re-establishes that, fixes #229, and introduces better debug output and a wait timer to the operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/233)
<!-- Reviewable:end -->
