### PR TITLE
gk-deploy: allow the heketi-service-account to view kubernetes info

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -443,6 +443,7 @@ if [[ ${LOAD} -eq 0 ]]; then
     eval_output "${CLI} adm policy add-scc-to-user privileged -z heketi-service-account"
   else
     eval_output "${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml 2>&1"
+    eval_output "${CLI} create clusterrolebinding heketi-sa-view --clusterrole=edit --serviceaccount=${NAMESPACE}:heketi-service-account 2>&1"
   fi
 fi
 


### PR DESCRIPTION
This is needed as of kubernetes 1.6 which defaults to RBAC
authorization.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/236)
<!-- Reviewable:end -->
