### PR TITLE
The latest version of Openshift depreate -v 'value'

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -476,10 +476,14 @@ fi
 
 if [[ ${LOAD} -eq 0 ]]; then
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    oc_version = $(${CLI} version | grep "oc")
+    if [[ "${oc_version}" == *3.4.* ]]; then
+      eval_output "${CLI} process -v HEKETI_ADMIN_KEY=${ADMIN_KEY} -v HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    else
+      eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    fi
   else
     eval_output "${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml 2>&1"
-  fi
 fi
 
 output -n "Waiting for deploy-heketi pod to start ... "
@@ -551,7 +555,12 @@ check_pods "job-name=heketi-storage-copy-job" "Completed"
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
 if [[ "${CLI}" == *oc\ * ]]; then
-  eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+    oc_version = $(${CLI} version | grep "oc")
+    if [[ "${oc_version}" == *3.4.* ]]; then
+      eval_output "${CLI} process -v HEKETI_ADMIN_KEY=${ADMIN_KEY} -v HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+    else
+      eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+    fi
 else
   eval_output "${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml 2>&1"
 fi


### PR DESCRIPTION
with -p value in 'oc process' command. This patch enables
gk-deploy's backward compatibility based on oc version.

Signed-off-by: hchiramm <hchiramm@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/242)
<!-- Reviewable:end -->
