### PR TITLE
make gk-deploy run with openshift 3.4 (origin 1.4) again

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -388,6 +388,14 @@ else
   exit 1
 fi
 
+if [[ "${CLI}" == *oc ]]; then
+  oc_minor_version=$(${CLI} version | grep oc | awk '{ print $2 }' | cut -d '.' -f2)
+  OC_PROCESS_VAL_SWITCH="-p"
+  if [[ ${oc_minor_version} -lt 5 ]]; then
+    OC_PROCESS_VAL_SWITCH="-v"
+  fi
+fi
+
 if [[ "x${TEMPLATES}" == "x" ]]; then
   if [[ "${CLI}" == *oc ]]; then
     TEMPLATES="${OCP_TEMPLATES_DEFAULT}"
@@ -476,7 +484,7 @@ fi
 
 if [[ ${LOAD} -eq 0 ]]; then
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
   else
     eval_output "${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml 2>&1"
   fi
@@ -551,7 +559,7 @@ check_pods "job-name=heketi-storage-copy-job" "Completed"
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
 if [[ "${CLI}" == *oc\ * ]]; then
-  eval_output "${CLI} process -p HEKETI_ADMIN_KEY=${ADMIN_KEY} -p HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+  eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
 else
   eval_output "${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml 2>&1"
 fi


### PR DESCRIPTION
The latest version of Openshift (3.5 / origin 1.5)
depreated -v 'value' in favor of  -p value in the 'oc process'
command. gk-deploy was recently changed to work with 3.5/1.5.

This patch enables gk-deploy's backward compatibility with
older versions based on the oc version.

Pair-Programmed-With: Michael Adam <obnox@redhat.com>

Signed-off-by: hchiramm <hchiramm@redhat.com>
Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/244)
<!-- Reviewable:end -->
