### PR TITLE
gk-deploy: fix error in check_pods() when second argument is a string

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -187,7 +187,16 @@ assign() {
 
 check_pods() {
   local rc=1
-  local wait_limit=${2:-${WAIT}}
+  local wait_limit=${WAIT}
+  local number_re='^[0-9]+$'
+
+  # $2 can either be a status string or
+  # a timeout integer. Only override the
+  # timeout if we get a numeric argument.
+  if [[ ${2} =~ $number_re ]]; then
+    wait_limit=${2}
+  fi
+
   s=0
   debug "\nChecking status of pods matching '${1}':"
   while [[ ${rc} -ne 0 ]]; do


### PR DESCRIPTION
The second argument of check_pods() can either be a timeout integer
value or a string to check for the status field. In the case of
a status string, it was mistakenly used as an override for the
timeout, leading to always error with timeout.

This patch lets check_pods inspect the second argument and only
use it as a timout override if it is numeric.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/245)
<!-- Reviewable:end -->
