### PR TITLE
abort if pods don't come up

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -555,6 +555,10 @@ fi
 eval_output "${CLI} create -f heketi-storage.json 2>&1"
 
 check_pods "job-name=heketi-storage-copy-job" "Completed"
+if [[ $? -ne 0 ]]; then
+  output "heketi-storage-copy-job timed out."
+  abort
+fi
 
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
@@ -566,6 +570,10 @@ fi
 
 output -n "Waiting for heketi pod to start ... "
 check_pods "glusterfs=heketi-pod"
+if [[ $? -ne 0 ]]; then
+  output "heketi pod not found."
+  abort
+fi
 output "OK"
 
 s=0


### PR DESCRIPTION
When storage-copy-job does not complete or when heketi pod does not
come up within timeout, we should not proceed with the deployment.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/246)
<!-- Reviewable:end -->
