### PR TITLE
should use namespace instead of context-name

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -430,7 +430,7 @@ if [[ -z "$NAMESPACE" ]]; then
   if [[ "${CLI}" == *oc ]]; then
     NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
   elif [[ "${CLI}" == *kubectl ]]; then
-    NAMESPACE=$(${CLI} config current-context)
+    NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
   fi
   if [[ -z "$NAMESPACE" ]]; then
     NAMESPACE="default"

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -427,11 +427,7 @@ if [[ "x${TEMPLATES}" == "x" ]]; then
 fi
 
 if [[ -z "$NAMESPACE" ]]; then
-  if [[ "${CLI}" == *oc ]]; then
-    NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
-  elif [[ "${CLI}" == *kubectl ]]; then
-    NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
-  fi
+  NAMESPACE=$(${CLI} config get-contexts | awk '/^\*/ {print $5}')
   if [[ -z "$NAMESPACE" ]]; then
     NAMESPACE="default"
   fi


### PR DESCRIPTION
context-name != current namespace for kubectl as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/264)
<!-- Reviewable:end -->
