### PR TITLE
Using port forward

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -581,7 +581,10 @@ if [[ ${?} != 0 ]]; then
   exit 1
 fi
 
+# this is for what is created by heketi-storage.json
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
+# this ist for what is created before
+eval_output "${CLI} delete -n ${NAMESPACE} all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
 if [[ "${CLI}" == *oc\ * ]]; then
   eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -481,7 +481,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   fi
   while read -r node; do
     debug "Marking '${node}' as a GlusterFS node."
-    eval_output "${CLI} label nodes ${node} storagenode=${DAEMONSET_LABEL} 2>&1"
+    eval_output "${CLI} label nodes ${node} storagenode=${DAEMONSET_LABEL} --overwrite 2>&1"
     if [[ ${?} -ne 0 ]]; then
       output "Failed to label node '${node}'"
       abort

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -172,6 +172,9 @@ abort() {
       eval_output "${CLI} delete template glusterfs 2>&1"
     fi
   fi
+  if ! [ -z ${port_forward_pid+x} ]; then 
+    kill -SIGKILL $port_forward_pid
+  fi
   exit 1
 }
 
@@ -529,7 +532,15 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   fi
   sleep 1
   ((s+=1))
-  heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
+  
+  if ! [[ "${CLI}" == *oc\ * ]]; then
+    echo "Starting port-forward"
+    heketi_pod=$(kubectl -n ${NAMESPACE} get pods -l glusterfs=heketi-pod -o name | sed 's/^.*\///')
+    kubectl -n ${NAMESPACE} port-forward ${heketi_pod} 8080:8080 >/dev/null &
+    port_forward_pid=$!
+    heketi_service="localhost:8080"
+    sleep 5
+  fi
 done
 
 if [[ "${CLI}" == *oc\ * ]]; then
@@ -611,8 +622,21 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   fi
   sleep 1
   ((s+=1))
-  heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
-done
+
+  echo "Killing old port forward"
+  kill -SIGKILL $port_forward_pid
+  sleep 1
+
+  if ! [[ "${CLI}" == *oc\ * ]]; then
+    echo "Starting port-forward"
+    heketi_pod=$(kubectl -n ${NAMESPACE} get pods -l glusterfs=heketi-pod -o name | sed 's/^.*\///')
+    kubectl -n ${NAMESPACE} port-forward ${heketi_pod} 8080:8080 >/dev/null &
+    port_forward_pid=$!
+    heketi_service="localhost:8080"
+    sleep 5
+  fi
+
+  done
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
@@ -628,6 +652,10 @@ if [[ "${hello}" != "Hello from Heketi" ]]; then
 else
   debug "OK"
   output "heketi is now running and accessible via http://${heketi_service}/"
+fi
+
+if ! [ -z ${port_forward_pid+x} ]; then 
+  kill -SIGKILL $port_forward_pid
 fi
 
 output "Ready to create and provide GlusterFS volumes."


### PR DESCRIPTION
Changes:

1. I do not know, how you expect to access the deploy-heketi endpoint by this script. IMHO a port-forward to the heketi-pod is one solution for _stock_ Kubernetes (querying for free local port is missing...)
2. I had some remaining k8s objects, depending on if the NS is the current context or as cmd line parameter to the script
3. I think node label overwrite is valid here (had some errrors on script restart, if abort() wasn't called before)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/265)
<!-- Reviewable:end -->
