### PR TITLE
Fixes the syntax error

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -412,7 +412,7 @@ else
 fi
 
 if [[ "${CLI}" == *oc ]]; then
-  oc_minor_version=$(${CLI} version | grep oc | awk '{ print $2 }' | cut -d '.' -f2)
+  oc_minor_version=$(${CLI} version | grep oc | head -1 | awk '{ print $2 }' | cut -d '.' -f2)
   OC_PROCESS_VAL_SWITCH="-p"
   if [[ ${oc_minor_version} -lt 5 ]]; then
     OC_PROCESS_VAL_SWITCH="-v"


### PR DESCRIPTION
If you have "oc" in your master api URL it spits out the following error

```
/usr/bin/cns-deploy: line 414: [[: 5
172: syntax error in expression (error token is "172")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/266)
<!-- Reviewable:end -->
