### PR TITLE
update yum repo url and disable gpg check

### DIFF
--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -22,17 +22,14 @@
   yum_repository:
     name: kubernetes
     description: Kubernetes
-    baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
+    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
     enabled: yes
-    gpgcheck: yes
-    repo_gpgcheck: yes
-    gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg
-      https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
 
 - name: install base packages
   yum:
     name: "{{ item }}"
     state: present
+    disable_gpg_check: yes
     update_cache: yes
   with_items: "{{ install_pkgs }}"
 


### PR DESCRIPTION
The yum URL now redirects to a different place, let us change to that.
Also, the packages might not be signed always, removing gpg check there.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/270)
<!-- Reviewable:end -->
