### PR TITLE
Use containerized heketi with non-containerized GlusterFS nodes

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -143,6 +143,7 @@ eval_output() {
     fi
     output "${line}"
   done < <(
+    debug "${cmd}"
     eval "${cmd}"
     echo "return $?"
   )

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -517,7 +517,7 @@ if [[ ${LOAD} -eq 0 ]]; then
   if [[ "${CLI}" == *oc\ * ]]; then
     eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
   else
-    eval_output "${CLI} create -f ${TEMPLATES}/deploy-heketi-deployment.yaml 2>&1"
+    eval_output "sed -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
   fi
 fi
 
@@ -596,7 +596,7 @@ eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deplo
 if [[ "${CLI}" == *oc\ * ]]; then
   eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
 else
-  eval_output "${CLI} create -f ${TEMPLATES}/heketi-deployment.yaml 2>&1"
+  eval_output "sed -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
 fi
 
 output -n "Waiting for heketi pod to start ... "

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -29,13 +29,19 @@ ABORT=0
 NODES=""
 SKIP_PREREQ=0
 LOAD=0
+EXECUTOR="kubernetes"
+SSH_KEYFILE="/dev/null"
+SSH_USER="root"
+SSH_SUDO="false"
+SSH_PORT="22"
 ADMIN_KEY=""
 USER_KEY=""
 DAEMONSET_LABEL=""
 
 usage() {
   echo -e "USAGE: ${PROG} [-ghvy] [-c CLI] [-t <TEMPLATES>] [-n NAMESPACE] [-w <SECONDS>]
-       [--load] [--admin-key <ADMIN_KEY>] [--user-key <USER_KEY>] [-l <LOG_FILE>]
+       [--load] [-s <KEYFILE>] [--ssh-user <USER>] [--ssh-port <PORT>]
+       [--admin-key <ADMIN_KEY>] [--user-key <USER_KEY>] [-l <LOG_FILE>]
        [--daemonset-label <DAEMONSET_LABEL> ]  [<TOPOLOGY>]\n"
 }
 
@@ -56,6 +62,19 @@ Options:
               indicates that all GlusterFS pods and deployments should be
               deleted as well. Default is to not handle GlusterFS deployment
               or removal.
+
+  -s, --ssh-keyfile KEYFILE
+              Path to an SSH private key. This key is required for heketi when
+              communicating with GlusterFS services not in pods. Specifying
+              this parameter switched heketi to use SSH directly instead of
+              Kubernetes APIs.
+
+  --ssh-user USER
+              User to use for SSH commands to GlusterFS nodes. Non-root users
+              must have sudo permissions on the nodes. Default is '${SSH_USER}'.
+
+  --ssh-port PORT
+              Port to use for SSH commands to GlusterFS nodes.
 
   -c CLI, --cli CLI
               Specify the container platform CLI (e.g. kubectl, oc) to use.
@@ -152,6 +171,7 @@ eval_output() {
 abort() {
   eval_output "${CLI} delete svc heketi 2>&1"
   eval_output "${CLI} delete sa heketi-service-account 2>&1"
+  eval_output "${CLI} delete secret heketi-config-secret 2>&1"
   eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
   eval_output "${CLI} delete svc/heketi-storage-endpoints 2>&1"
   if [[ "${CLI}" == *oc\ * ]]; then
@@ -256,6 +276,25 @@ while [[ $# -ge 1 ]]; do
         g*|-deploy-gluster)
         GLUSTER=1
         if [[ "$key" == "--deploy-gluster" ]]; then keypos=$keylen; fi
+        ;;
+        s*|-ssh-keyfile)
+        EXECUTOR="ssh"
+        SSH_KEYFILE=$(assign "${key:${keypos}}" "${2}")
+        if [[ $? -eq 2 ]]; then shift; fi
+        keypos=$keylen
+        ;;
+        -ssh-user)
+        SSH_USER=$(assign "${key:${keypos}}" "${2}")
+        if [[ "${SSH_USER}" != "root" ]]; then
+          SSH_SUDO="true"
+        fi
+        if [[ $? -eq 2 ]]; then shift; fi
+        keypos=$keylen
+        ;;
+        -ssh-port)
+        SSH_PORT=$(assign "${key:${keypos}}" "${2}")
+        if [[ $? -eq 2 ]]; then shift; fi
+        keypos=$keylen
         ;;
         n*|-namespace*)
         NAMESPACE=$(assign "${key:${keypos}}" "${2}")
@@ -462,6 +501,24 @@ if [[ ${ABORT} -eq 1 ]]; then
   abort
 fi
 
+if [[ "${EXECUTOR}" == "ssh" ]]; then
+  while read -r node; do
+    debug "Checking glusterd status on '${node}'."
+    if [[ "${SSH_SUDO}" == "true" ]]; then
+      sudocmd="sudo "
+    else
+      sudocmd=""
+    fi
+    # shellcheck disable=SC2029
+    # I want this parsed client-side
+    ssh "${SSH_USER}@${node}" -q -i "${SSH_KEYFILE}" -C "${sudocmd}gluster volume status" >/dev/null 2>&1
+    if [[ ${?} -ne 0 ]]; then
+      output "Can't access glusterd on '${node}'"
+      exit 1
+    fi
+  done <<< "$(echo -e "${NODES}")"
+fi
+
 if [[ ${LOAD} -eq 0 ]]; then
   output -n "Checking that heketi pod is not running ... "
   check_pods "glusterfs=heketi-pod" 2
@@ -514,10 +571,12 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
 fi
 
 if [[ ${LOAD} -eq 0 ]]; then
+  sed -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" heketi.json.template > heketi.json
+  eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json"
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
   else
-    eval_output "sed -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
+    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
   fi
 fi
 
@@ -594,9 +653,9 @@ fi
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
 if [[ "${CLI}" == *oc\ * ]]; then
-  eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+  eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
 else
-  eval_output "sed -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
+  eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
 fi
 
 output -n "Waiting for heketi pod to start ... "

--- a/deploy/heketi.json.template
+++ b/deploy/heketi.json.template
@@ -1,0 +1,36 @@
+{
+	"_port_comment": "Heketi Server Port Number",
+	"port" : "8080",
+
+	"_use_auth": "Enable JWT authorization. Please enable for deployment",
+	"use_auth" : false,
+
+	"_jwt" : "Private keys for access",
+	"jwt" : {
+		"_admin" : "Admin has access to all APIs",
+		"admin" : {
+			"key" : "My Secret"
+		},
+		"_user" : "User only has access to /volumes endpoint",
+		"user" : {
+			"key" : "My Secret"
+		}
+	},
+
+	"_glusterfs_comment": "GlusterFS Configuration",
+	"glusterfs" : {
+
+		"_executor_comment": "Execute plugin. Possible choices: mock, kubernetes, ssh",
+		"executor" : "{{ glusterfs_heketi_executor }}",
+
+		"_db_comment": "Database file name",
+		"db" : "/var/lib/heketi/heketi.db",
+
+		"sshexec" : {
+			"keyfile" : "/etc/heketi/private_key",
+			"port" : "${SSH_PORT}",
+			"user" : "${SSH_USER}",
+			"sudo" : ${SSH_SUDO}
+		}
+	}
+}

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - name: HEKETI_ADMIN_KEY
           value: ${HEKETI_ADMIN_KEY}
         - name: HEKETI_EXECUTOR
-          value: kubernetes
+          value: ${HEKETI_EXECUTOR}
         - name: HEKETI_FSTAB
           value: "/var/lib/heketi/fstab"
         - name: HEKETI_SNAPSHOT_LIMIT
@@ -57,6 +57,8 @@ spec:
         volumeMounts:
         - name: db
           mountPath: "/var/lib/heketi"
+        - name: config
+          mountPath: /etc/heketi
         readinessProbe:
           timeoutSeconds: 3
           initialDelaySeconds: 3
@@ -71,3 +73,6 @@ spec:
             port: 8080
       volumes:
       - name: db
+      - name: config
+        secret:
+          secretName: heketi-config-secret

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -40,6 +40,10 @@ spec:
         imagePullPolicy: IfNotPresent
         name: deploy-heketi
         env:
+        - name: HEKETI_USER_KEY
+          value: ${HEKETI_USER_KEY}
+        - name: HEKETI_ADMIN_KEY
+          value: ${HEKETI_ADMIN_KEY}
         - name: HEKETI_EXECUTOR
           value: kubernetes
         - name: HEKETI_FSTAB

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: HEKETI_ADMIN_KEY
           value: ${HEKETI_ADMIN_KEY}
         - name: HEKETI_EXECUTOR
-          value: kubernetes
+          value: ${HEKETI_EXECUTOR}
         - name: HEKETI_FSTAB
           value: "/var/lib/heketi/fstab"
         - name: HEKETI_SNAPSHOT_LIMIT
@@ -54,6 +54,8 @@ spec:
         volumeMounts:
         - name: db
           mountPath: "/var/lib/heketi"
+        - name: config
+          mountPath: /etc/heketi
         readinessProbe:
           timeoutSeconds: 3
           initialDelaySeconds: 3
@@ -71,3 +73,6 @@ spec:
         glusterfs:
           endpoints: heketi-storage-endpoints
           path: heketidbstorage
+      - name: config
+        secret:
+          secretName: heketi-config-secret

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -37,6 +37,10 @@ spec:
         imagePullPolicy: IfNotPresent
         name: heketi
         env:
+        - name: HEKETI_USER_KEY
+          value: ${HEKETI_USER_KEY}
+        - name: HEKETI_ADMIN_KEY
+          value: ${HEKETI_ADMIN_KEY}
         - name: HEKETI_EXECUTOR
           value: kubernetes
         - name: HEKETI_FSTAB

--- a/deploy/ocp-templates/deploy-heketi-template.yaml
+++ b/deploy/ocp-templates/deploy-heketi-template.yaml
@@ -74,7 +74,7 @@ objects:
           - name: HEKETI_ADMIN_KEY
             value: ${HEKETI_ADMIN_KEY}
           - name: HEKETI_EXECUTOR
-            value: kubernetes
+            value: ${HEKETI_EXECUTOR}
           - name: HEKETI_FSTAB
             value: /var/lib/heketi/fstab
           - name: HEKETI_SNAPSHOT_LIMIT
@@ -86,6 +86,8 @@ objects:
           volumeMounts:
           - name: db
             mountPath: /var/lib/heketi
+          - name: config
+            mountPath: /etc/heketi
           readinessProbe:
             timeoutSeconds: 3
             initialDelaySeconds: 3
@@ -100,6 +102,9 @@ objects:
               port: 8080
         volumes:
         - name: db
+        - name: config
+          secret:
+            secretName: heketi-config-secret
 parameters:
 - name: HEKETI_USER_KEY
   displayName: Heketi User Secret
@@ -107,3 +112,7 @@ parameters:
 - name: HEKETI_ADMIN_KEY
   displayName: Heketi Administrator Secret
   description: Set secret for administration of the Heketi service as user _admin_
+- name: HEKETI_EXECUTOR
+  displayName: heketi executor type
+  description: Set the executor type, kubernetes or ssh
+  value: kubernetes

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -69,7 +69,7 @@ objects:
           - name: HEKETI_ADMIN_KEY
             value: ${HEKETI_ADMIN_KEY}
           - name: HEKETI_EXECUTOR
-            value: kubernetes
+            value: ${HEKETI_EXECUTOR}
           - name: HEKETI_FSTAB
             value: /var/lib/heketi/fstab
           - name: HEKETI_SNAPSHOT_LIMIT
@@ -81,6 +81,8 @@ objects:
           volumeMounts:
           - name: db
             mountPath: /var/lib/heketi
+          - name: config
+            mountPath: /etc/heketi
           readinessProbe:
             timeoutSeconds: 3
             initialDelaySeconds: 3
@@ -98,6 +100,9 @@ objects:
           glusterfs:
             endpoints: heketi-storage-endpoints
             path: heketidbstorage
+        - name: config
+          secret:
+            secretName: heketi-config-secret
 parameters:
 - name: HEKETI_USER_KEY
   displayName: Heketi User Secret
@@ -105,3 +110,7 @@ parameters:
 - name: HEKETI_ADMIN_KEY
   displayName: Heketi Administrator Secret
   description: Set secret for administration of the Heketi service as user _admin_
+- name: HEKETI_EXECUTOR
+  displayName: heketi executor type
+  description: Set the executor type, kubernetes or ssh
+  value: kubrenetes


### PR DESCRIPTION
This PR intends to allow gk-deploy to deploy a solution where heketi remains containerized and manages a set of non-containerized GlusterFS nodes. In its most basic form, this new functionality can be achieved by running:

```
gk-deploy -s <keyfile>
```

Where `<keyfile>` is a path to an SSH private key that can be used to get acces to either root or a sudoable account on the GlusterFS nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/281)
<!-- Reviewable:end -->
