### PR TITLE
Introduce idempotent execution in gk-deploy

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -690,6 +690,9 @@ fi
 
 eval_output "${CLI} label --overwrite svc heketi-storage-endpoints glusterfs=heketi-storage-endpoints heketi=storage-endpoints"
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
+if [[ "${CLI}" == *oc\ * ]]; then
+  eval_output "${CLI} delete dc,route,template --selector=\"deploy-heketi\" 2>&1"
+fi
 
 if [[ "${CLI}" == *oc\ * ]]; then
   eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -579,7 +579,7 @@ if [[ ${LOAD} -eq 0 ]]; then
   fi
 fi
 
-if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
+if [[ ${GLUSTER} -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   if [[ -z ${DAEMONSET_LABEL} ]]; then
     DAEMONSET_LABEL=glusterfs
   fi

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -99,14 +99,13 @@ Options:
               deployment and re-run topology load command.
 
   --admin-key ADMIN_KEY
-              Secret for heketi administrator user. Heketi admin has access to all
-              the APIs. admin key: string, Shared secret.
-              Eg: MySecret
+              Secret string for heketi admin user. heketi admin has access to
+              all APIs and commands. Default is to use no secret.
 
   --user-key USER_KEY
-              Secret for heketi general user. Heketi user has access to only Volume
-              APIs. user key: string, Shared secret.
-              Eg: MyVolumeSecret
+              Secret string for general heketi users. heketi users have access
+              to only Volume APIs. Used in dynamic provisioning. Default is to
+              use no secret.
 
   --daemonset-label DAEMONSET_LABEL
               Controls the value of the label set on nodes which will host pods

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -28,7 +28,9 @@ WAIT=300
 ABORT=0
 NODES=""
 SKIP_PREREQ=0
-LOAD=0
+EXISTS_GLUSTERFS=0
+EXISTS_DEPLOY_HEKETI=0
+EXISTS_HEKETI=0
 EXECUTOR="kubernetes"
 SSH_KEYFILE="/dev/null"
 SSH_USER="root"
@@ -40,7 +42,7 @@ DAEMONSET_LABEL=""
 
 usage() {
   echo -e "USAGE: ${PROG} [-ghvy] [-c CLI] [-t <TEMPLATES>] [-n NAMESPACE] [-w <SECONDS>]
-       [--load] [-s <KEYFILE>] [--ssh-user <USER>] [--ssh-port <PORT>]
+       [-s <KEYFILE>] [--ssh-user <USER>] [--ssh-port <PORT>]
        [--admin-key <ADMIN_KEY>] [--user-key <USER_KEY>] [-l <LOG_FILE>]
        [--daemonset-label <DAEMONSET_LABEL> ]  [<TOPOLOGY>]\n"
 }
@@ -92,11 +94,6 @@ Options:
 
   -w SECONDS, --wait SECONDS
               Wait SECONDS seconds for pods to become ready. Default is '${WAIT}'.
-
-  --load      Resumes from the Topology load. Used in case of topology load
-              failure on adding nodes or devices to heketi. Fix the issue on
-              device or node, then restart with --load to skip gluster
-              deployment and re-run topology load command.
 
   --admin-key ADMIN_KEY
               Secret string for heketi admin user. heketi admin has access to
@@ -378,10 +375,6 @@ while [[ $# -ge 1 ]]; do
         h*|-help)
         help_exit
         ;;
-        -load)
-        LOAD=1
-        keypos=$keylen
-        ;;
         v*|-verbose)
         VERBOSE=1
         if [[ "$key" == "--verbose" ]]; then keypos=$keylen; fi
@@ -402,7 +395,7 @@ while [[ $# -ge 1 ]]; do
   shift
 done
 
-if [[ ${LOAD} -eq 0 ]] && [[ ${ABORT} -eq 0 ]] && [[ ${SKIP_PREREQ} -eq 0 ]]; then
+if [[ ${ABORT} -eq 0 ]] && [[ ${SKIP_PREREQ} -eq 0 ]]; then
   echo "Welcome to the deployment tool for GlusterFS on Kubernetes and OpenShift.
 
 Before getting started, this script has some requirements of the execution
@@ -554,14 +547,37 @@ if [[ "${EXECUTOR}" == "ssh" ]]; then
   done <<< "$(echo -e "${NODES}")"
 fi
 
-if [[ ${LOAD} -eq 0 ]]; then
-  output -n "Checking that heketi pod is not running ... "
-  check_pods "heketi=pod" 2
-  if [[ $? -eq 0 ]]; then
-    output "Found heketi pod running. Please destroy existing setup and try again."
-    exit 1
-  fi
-  output "OK"
+output "Checking for pre-existing resources..."
+
+output -n "  GlusterFS pods ... "
+check_pods "glusterfs=pod" 2 2>&1
+if [[ $? -eq 0 ]]; then
+  EXISTS_GLUSTERFS=1
+  output "found."
+else
+  output "not found."
+fi
+
+output -n "  deploy-heketi pod ... "
+check_pods "deploy-heketi=pod" 2 2>&1
+if [[ $? -eq 0 ]]; then
+  EXISTS_DEPLOY_HEKETI=1
+  output "found."
+else
+  output "not found."
+fi
+
+output -n "  heketi pod ... "
+check_pods "heketi=pod" 2 2>&1
+if [[ $? -eq 0 ]]; then
+  EXISTS_HEKETI=1
+  output "found."
+else
+  output "not found."
+fi
+
+if [[ ${EXISTS_HEKETI} -eq 0 ]]; then
+  output -n "Creating initial resources ... "
   if [[ "${CLI}" == *oc\ * ]]; then
     eval_output "${CLI} create -f ${TEMPLATES}/deploy-heketi-template.yaml 2>&1"
     eval_output "${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml 2>&1"
@@ -576,9 +592,10 @@ if [[ ${LOAD} -eq 0 ]]; then
     eval_output "${CLI} create clusterrolebinding heketi-sa-view --clusterrole=edit --serviceaccount=${NAMESPACE}:heketi-service-account 2>&1"
     eval_output "${CLI} label --overwrite clusterrolebinding heketi-sa-view glusterfs=heketi-sa-view heketi=sa-view"
   fi
+  output "OK"
 fi
 
-if [[ ${GLUSTER} -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
+if [[ ${GLUSTER} -eq 1 ]] && [[ ${EXISTS_GLUSTERFS} -eq 0 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
   if [[ -z ${DAEMONSET_LABEL} ]]; then
     DAEMONSET_LABEL=glusterfs
   fi
@@ -604,9 +621,10 @@ if [[ ${GLUSTER} -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
     exit 1
   fi
   output "OK"
+  EXISTS_GLUSTERFS=1
 fi
 
-if [[ ${LOAD} -eq 0 ]]; then
+if [[ ${EXISTS_DEPLOY_HEKETI} -eq 0 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
   sed -e "s/\${HEKETI_EXECUTOR}/${EXECUTOR}/" -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" heketi.json.template > heketi.json
   eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json --from-file=topology.json=${TOPOLOGY}"
   eval_output "${CLI} label --overwrite secret heketi-config-secret glusterfs=heketi-config-secret heketi=config-secret"
@@ -615,106 +633,111 @@ if [[ ${LOAD} -eq 0 ]]; then
   else
     eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
   fi
-fi
 
-output -n "Waiting for deploy-heketi pod to start ... "
-check_pods "deploy-heketi=pod"
-if [[ $? -ne 0 ]]; then
-  output "pods not found."
-  exit 1
-fi
-output "OK"
-
-s=0
-heketi_service=""
-debug -n "Determining heketi service URL ... "
-while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
-  if [[ ${s} -ge ${WAIT} ]]; then
-    debug "Timed out waiting for deploy-heketi service."
-    break
-  fi
-  sleep 1
-  ((s+=1))
-  heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
-done
-
-if [[ "${CLI}" == *oc\ * ]]; then
-  heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
-fi
-
-hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
-if [[ "${hello}" != "Hello from Heketi" ]]; then
-  output "Failed to communicate with deploy-heketi service."
-  if [[ "${CLI}" == *oc\ * ]]; then
-    output "Please verify that a router has been properly configured."
-  fi
-  exit 1
-else
-  debug "OK"
-fi
-
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" 2>&1 | awk '{print $1}')
-heketi_cli="${CLI} exec -it ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
-
-load_temp=$(mktemp)
-eval_output "${heketi_cli} topology load --json=/etc/heketi/topology.json 2>&1" | tee "${load_temp}"
-grep -q "Unable" "${load_temp}"
-unable=$?
-rm "${load_temp}"
-
-if [[ ${PIPESTATUS[0]} -ne 0 ]] || [[ ${unable} -eq 0 ]]; then
-  output "Error loading the cluster topology."
-  if [[ ${unable} -eq 0 ]]; then
-    output "Please check the failed node or device and rerun this script using the --load option."
-  fi
-  exit 1
-else
-  output "heketi topology loaded."
-fi
-
-if [[ $("${heketi_cli}" volume list 2>&1) != *heketidbstorage* ]]; then
-  eval_output "${heketi_cli} setup-openshift-heketi-storage 2>&1"
-  if [[ ${?} != 0 ]]; then
-    output "Failed on setup openshift heketi storage"
+  output -n "Waiting for deploy-heketi pod to start ... "
+  check_pods "deploy-heketi=pod"
+  if [[ $? -ne 0 ]]; then
+    output "pod not found."
     exit 1
   fi
-else
-  output "Volume heketidbstorage not found."
-  exit 1
+  output "OK"
+  EXISTS_DEPLOY_HEKETI=1
 fi
 
-eval_output "${CLI} exec -it ${heketi_pod} -- cat heketi-storage.json | ${CLI} create -f - 2>&1"
-if [[ ${?} != 0 ]]; then
-  output "Failed on creating heketi storage resources."
-  exit 1
+if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
+  s=0
+  heketi_service=""
+  debug -n "Determining heketi service URL ... "
+  while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]; do
+    if [[ ${s} -ge ${WAIT} ]]; then
+      debug "Timed out waiting for deploy-heketi service."
+      break
+    fi
+    sleep 1
+    ((s+=1))
+    heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
+  done
+
+  if [[ "${CLI}" == *oc\ * ]]; then
+    heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
+  fi
+
+  hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
+  if [[ "${hello}" != "Hello from Heketi" ]]; then
+    output "Failed to communicate with deploy-heketi service."
+    if [[ "${CLI}" == *oc\ * ]]; then
+      output "Please verify that a router has been properly configured."
+    fi
+    exit 1
+  else
+    debug "OK"
+  fi
+
+  heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" 2>&1 | awk '{print $1}')
+  heketi_cli="${CLI} exec -it ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
+
+  load_temp=$(mktemp)
+  eval_output "${heketi_cli} topology load --json=/etc/heketi/topology.json 2>&1" | tee "${load_temp}"
+  grep -q "Unable" "${load_temp}"
+  unable=$?
+  rm "${load_temp}"
+
+  if [[ ${PIPESTATUS[0]} -ne 0 ]] || [[ ${unable} -eq 0 ]]; then
+    output "Error loading the cluster topology."
+    if [[ ${unable} -eq 0 ]]; then
+      output "Please check the failed node or device and rerun this script."
+    fi
+    exit 1
+  else
+    output "heketi topology loaded."
+  fi
+
+  if [[ $("${heketi_cli}" volume list 2>&1) != *heketidbstorage* ]]; then
+    eval_output "${heketi_cli} setup-openshift-heketi-storage 2>&1"
+    if [[ ${?} != 0 ]]; then
+      output "Failed on setup openshift heketi storage"
+      exit 1
+    fi
+  else
+    output "Volume heketidbstorage not found."
+    exit 1
+  fi
+
+  eval_output "${CLI} exec -it ${heketi_pod} -- cat heketi-storage.json | ${CLI} create -f - 2>&1"
+  if [[ ${?} != 0 ]]; then
+    output "Failed on creating heketi storage resources."
+    exit 1
+  fi
+
+  check_pods "job-name=heketi-storage-copy-job" "Completed"
+  if [[ ${?} != 0 ]]; then
+    output "Error waiting for job 'heketi-storage-copy-job' to complete."
+    exit 1
+  fi
+
+  eval_output "${CLI} label --overwrite svc heketi-storage-endpoints glusterfs=heketi-storage-endpoints heketi=storage-endpoints"
+  eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
+  if [[ "${CLI}" == *oc\ * ]]; then
+    eval_output "${CLI} delete dc,route,template --selector=\"deploy-heketi\" 2>&1"
+  fi
 fi
 
-check_pods "job-name=heketi-storage-copy-job" "Completed"
-if [[ ${?} != 0 ]]; then
-  output "Error waiting for job 'heketi-storage-copy-job' to complete."
-  exit 1
-fi
+if [[ ${EXISTS_HEKETI} -eq 0 ]]; then
+  if [[ "${CLI}" == *oc\ * ]]; then
+    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+  else
+    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
+  fi
 
-eval_output "${CLI} label --overwrite svc heketi-storage-endpoints glusterfs=heketi-storage-endpoints heketi=storage-endpoints"
-eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
-if [[ "${CLI}" == *oc\ * ]]; then
-  eval_output "${CLI} delete dc,route,template --selector=\"deploy-heketi\" 2>&1"
+  output -n "Waiting for heketi pod to start ... "
+  check_pods "heketi=pod"
+  if [[ ${?} != 0 ]]; then
+    output "pod not found"
+    exit 1
+  fi
+  output "OK"
+  EXISTS_HEKETI=1
 fi
-
-if [[ "${CLI}" == *oc\ * ]]; then
-  eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
-else
-  eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
-fi
-
-output -n "Waiting for heketi pod to start ... "
-check_pods "heketi=pod"
-if [[ ${?} != 0 ]]; then
-  output "pod not found"
-  exit 1
-fi
-
-output "OK"
 
 s=0
 heketi_service=""
@@ -752,8 +775,25 @@ You can find it at https://github.com/heketi/heketi/releases . Alternatively,
 use it from within the heketi pod:
 
   # ${CLI} exec -it <HEKETI_POD> -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
-"
 
+For dynamic provisioning, create a StorageClass similar to this:
+
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: glusterfs-storage
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: \"http://${heketi_service}\""
+  if [[ "x${USER_KEY}" != "x" ]]; then
+    output "  restuser: \"user\"
+  restuserkey: \"${USER_KEY}\""
+  fi
+  output ""
 fi
 
-output "Ready to create and provide GlusterFS volumes."
+
+output "
+Deployment complete!
+"

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -184,28 +184,22 @@ eval_output() {
 #   resources. NOTE: This does not wipe the storage devices used by GlusterFS.
 
 abort() {
-  eval_output "${CLI} delete svc heketi 2>&1"
-  eval_output "${CLI} delete sa heketi-service-account 2>&1"
-  eval_output "${CLI} delete secret heketi-config-secret 2>&1"
-  eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
-  eval_output "${CLI} delete svc/heketi-storage-endpoints 2>&1"
+  debug "Removing heketi resources."
+  eval_output "${CLI} delete all,svc,jobs,deploy,secret --selector=\"deploy-heketi\" 2>&1"
+  eval_output "${CLI} delete all,svc,deploy,secret,sa,clusterrolebinding --selector=\"heketi\" 2>&1"
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} delete dc,route heketi 2>&1"
-    eval_output "${CLI} delete template deploy-heketi 2>&1"
-    eval_output "${CLI} delete template heketi 2>&1"
-  else
-    eval_output "${CLI} delete clusterrolebinding heketi-sa-view 2>&1"
-    eval_output "${CLI} delete deployment heketi 2>&1"
+    eval_output "${CLI} delete dc,route,template --selector=\"deploy-heketi\" 2>&1"
+    eval_output "${CLI} delete dc,route,template --selector=\"heketi\" 2>&1"
   fi
   if [[ ${GLUSTER} -eq 1 ]]; then
     while read -r node; do
       debug "Removing label from '${node}' as a GlusterFS node."
       eval_output "${CLI} label nodes \"${node}\" storagenode- 2>&1"
     done <<< "$(echo -e "${NODES}")"
-    debug "Removing daemonset glusterfs."
+    debug "Removing glusterfs daemonset."
     eval_output "${CLI} delete ds --selector=\"glusterfs\" 2>&1"
     if [[ "${CLI}" == *oc\ * ]]; then
-      eval_output "${CLI} delete template glusterfs 2>&1"
+      eval_output "${CLI} delete template --selector=\"glusterfs\" 2>&1"
     fi
   fi
   exit 1
@@ -563,7 +557,7 @@ fi
 
 if [[ ${LOAD} -eq 0 ]]; then
   output -n "Checking that heketi pod is not running ... "
-  check_pods "glusterfs=heketi-pod" 2
+  check_pods "heketi=pod" 2
   if [[ $? -eq 0 ]]; then
     output "Found heketi pod running. Please destroy existing setup and try again."
     exit 1
@@ -581,6 +575,7 @@ if [[ ${LOAD} -eq 0 ]]; then
   else
     eval_output "${CLI} create -f ${TEMPLATES}/heketi-service-account.yaml 2>&1"
     eval_output "${CLI} create clusterrolebinding heketi-sa-view --clusterrole=edit --serviceaccount=${NAMESPACE}:heketi-service-account 2>&1"
+    eval_output "${CLI} label --overwrite clusterrolebinding heketi-sa-view glusterfs=heketi-sa-view heketi=sa-view"
   fi
 fi
 
@@ -604,7 +599,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   fi
 
   output -n "Waiting for GlusterFS pods to start ... "
-  check_pods "glusterfs-node=pod"
+  check_pods "glusterfs=pod"
   if [[ $? -ne 0 ]]; then
     output "pods not found."
     abort
@@ -615,6 +610,7 @@ fi
 if [[ ${LOAD} -eq 0 ]]; then
   sed -e "s/\${HEKETI_EXECUTOR}/${EXECUTOR}/" -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" heketi.json.template > heketi.json
   eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json"
+  eval_output "${CLI} label --overwrite secret heketi-config-secret glusterfs=heketi-config-secret heketi=config-secret"
   if [[ "${CLI}" == *oc\ * ]]; then
     eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
   else
@@ -623,7 +619,7 @@ if [[ ${LOAD} -eq 0 ]]; then
 fi
 
 output -n "Waiting for deploy-heketi pod to start ... "
-check_pods "glusterfs=heketi-pod"
+check_pods "deploy-heketi=pod"
 if [[ $? -ne 0 ]]; then
   output "pods not found."
   abort
@@ -692,6 +688,7 @@ if [[ ${?} != 0 ]]; then
   exit 1
 fi
 
+eval_output "${CLI} label --overwrite svc heketi-storage-endpoints glusterfs=heketi-storage-endpoints heketi=storage-endpoints"
 eval_output "${CLI} delete all,service,jobs,deployment,secret --selector=\"deploy-heketi\" 2>&1"
 
 if [[ "${CLI}" == *oc\ * ]]; then
@@ -701,7 +698,7 @@ else
 fi
 
 output -n "Waiting for heketi pod to start ... "
-check_pods "glusterfs=heketi-pod"
+check_pods "heketi=pod"
 if [[ ${?} != 0 ]]; then
   output "pod not found"
   exit 1

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -588,7 +588,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
     eval_output "${CLI} label nodes ${node} storagenode=${DAEMONSET_LABEL} 2>&1"
     if [[ ${?} -ne 0 ]]; then
       output "Failed to label node '${node}'"
-      abort
+      exit 1
     fi
   done <<< "$(echo -e "${NODES}")"
   debug "Deploying GlusterFS pods."
@@ -602,7 +602,7 @@ if [[ $GLUSTER -eq 1 ]] && [[ ${LOAD} -eq 0 ]]; then
   check_pods "glusterfs=pod"
   if [[ $? -ne 0 ]]; then
     output "pods not found."
-    abort
+    exit 1
   fi
   output "OK"
 fi
@@ -622,7 +622,7 @@ output -n "Waiting for deploy-heketi pod to start ... "
 check_pods "deploy-heketi=pod"
 if [[ $? -ne 0 ]]; then
   output "pods not found."
-  abort
+  exit 1
 fi
 output "OK"
 
@@ -649,7 +649,7 @@ if [[ "${hello}" != "Hello from Heketi" ]]; then
   if [[ "${CLI}" == *oc\ * ]]; then
     output "Please verify that a router has been properly configured."
   fi
-  abort
+  exit 1
 else
   debug "OK"
 fi

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -411,7 +411,6 @@ environment and of the container platform that you should verify.
 The client machine that will run this script must have:
  * Administrative access to an existing Kubernetes or OpenShift cluster
  * Access to a python interpreter 'python'
- * Access to the heketi client 'heketi-cli'
 
 Each of the nodes that will host GlusterFS must also have appropriate firewall
 rules for the required GlusterFS ports:
@@ -609,7 +608,7 @@ fi
 
 if [[ ${LOAD} -eq 0 ]]; then
   sed -e "s/\${HEKETI_EXECUTOR}/${EXECUTOR}/" -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" heketi.json.template > heketi.json
-  eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json"
+  eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json --from-file=topology.json=${TOPOLOGY}"
   eval_output "${CLI} label --overwrite secret heketi-config-secret glusterfs=heketi-config-secret heketi=config-secret"
   if [[ "${CLI}" == *oc\ * ]]; then
     eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
@@ -654,8 +653,11 @@ else
   debug "OK"
 fi
 
+heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" 2>&1 | awk '{print $1}')
+heketi_cli="${CLI} exec -it ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
+
 load_temp=$(mktemp)
-eval_output "heketi-cli -s http://${heketi_service} --user admin --secret \"${ADMIN_KEY}\" topology load --json=${TOPOLOGY} 2>&1" | tee "${load_temp}"
+eval_output "${heketi_cli} topology load --json=/etc/heketi/topology.json 2>&1" | tee "${load_temp}"
 grep -q "Unable" "${load_temp}"
 unable=$?
 rm "${load_temp}"
@@ -670,17 +672,22 @@ else
   output "heketi topology loaded."
 fi
 
-eval_output "heketi-cli -s http://${heketi_service} --user admin --secret \"${ADMIN_KEY}\" setup-openshift-heketi-storage 2>&1"
-if [[ ${?} != 0 ]]; then
-  output "Failed on setup openshift heketi storage"
+if [[ $("${heketi_cli}" volume list 2>&1) != *heketidbstorage* ]]; then
+  eval_output "${heketi_cli} setup-openshift-heketi-storage 2>&1"
+  if [[ ${?} != 0 ]]; then
+    output "Failed on setup openshift heketi storage"
+    exit 1
+  fi
+else
+  output "Volume heketidbstorage not found."
   exit 1
 fi
 
-if [[ ! -f heketi-storage.json ]]; then
-  output "heketi-storage.json file not found"
+eval_output "${CLI} exec -it ${heketi_pod} -- cat heketi-storage.json | ${CLI} create -f - 2>&1"
+if [[ ${?} != 0 ]]; then
+  output "Failed on creating heketi storage resources."
   exit 1
 fi
-eval_output "${CLI} create -f heketi-storage.json 2>&1"
 
 check_pods "job-name=heketi-storage-copy-job" "Completed"
 if [[ ${?} != 0 ]]; then
@@ -735,7 +742,18 @@ if [[ "${hello}" != "Hello from Heketi" ]]; then
   exit 1
 else
   debug "OK"
-  output "heketi is now running and accessible via http://${heketi_service}/"
+  output "
+heketi is now running and accessible via http://${heketi_service} . To run
+administrative commands you can install 'heketi-cli' and use it as follows:
+
+  # heketi-cli -s http://${heketi_service} --user admin --secret '<ADMIN_KEY>' cluster list
+
+You can find it at https://github.com/heketi/heketi/releases . Alternatively,
+use it from within the heketi pod:
+
+  # ${CLI} exec -it <HEKETI_POD> -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
+"
+
 fi
 
 output "Ready to create and provide GlusterFS volumes."

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -5,12 +5,12 @@ metadata:
   name: deploy-heketi
   labels:
     glusterfs: heketi-service
-    deploy-heketi: support
+    deploy-heketi: service
   annotations:
     description: Exposes Heketi Service
 spec:
   selector:
-    name: deploy-heketi
+    deploy-heketi: pod
   ports:
   - name: deploy-heketi
     port: 8080
@@ -22,7 +22,7 @@ metadata:
   name: deploy-heketi
   labels:
     glusterfs: heketi-deployment
-    deploy-heketi: heketi-deployment
+    deploy-heketi: deployment
   annotations:
     description: Defines how to deploy Heketi
 spec:
@@ -31,8 +31,8 @@ spec:
     metadata:
       name: deploy-heketi
       labels:
-        name: deploy-heketi
         glusterfs: heketi-pod
+        deploy-heketi: pod
     spec:
       serviceAccountName: heketi-service-account
       containers:

--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       name: glusterfs
       labels:
+        glusterfs: pod
         glusterfs-node: pod
     spec:
       nodeSelector:

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: heketi
   labels:
     glusterfs: heketi-service
+    heketi: service
   annotations:
     description: Exposes Heketi Service
 spec:
@@ -21,6 +22,7 @@ metadata:
   name: heketi
   labels:
     glusterfs: heketi-deployment
+    heketi: deployment
   annotations:
     description: Defines how to deploy Heketi
 spec:
@@ -30,6 +32,7 @@ spec:
       name: heketi
       labels:
         glusterfs: heketi-pod
+        heketi: pod
     spec:
       serviceAccountName: heketi-service-account
       containers:

--- a/deploy/kube-templates/heketi-service-account.yaml
+++ b/deploy/kube-templates/heketi-service-account.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: heketi-service-account
+  labels:
+    glusterfs: heketi-sa
+    heketi: sa

--- a/deploy/ocp-templates/deploy-heketi-template.yaml
+++ b/deploy/ocp-templates/deploy-heketi-template.yaml
@@ -5,12 +5,10 @@ metadata:
   name: deploy-heketi
   labels:
     glusterfs: heketi-template
-    deploy-heketi: support
+    deploy-heketi: template
   annotations:
     description: Bootstrap Heketi installation
     tags: glusterfs,heketi,installation
-labels:
-  template: deploy-heketi
 objects:
 - kind: Service
   apiVersion: v1
@@ -18,7 +16,7 @@ objects:
     name: deploy-heketi
     labels:
       glusterfs: heketi-service
-      deploy-heketi: support
+      deploy-heketi: service
     annotations:
       description: Exposes Heketi service
   spec:
@@ -34,7 +32,7 @@ objects:
     name: deploy-heketi
     labels:
       glusterfs: heketi-route
-      deploy-heketi: support
+      deploy-heketi: route
   spec:
     to:
       kind: Service
@@ -45,13 +43,13 @@ objects:
     name: deploy-heketi
     labels:
       glusterfs: heketi-dc
-      deploy-heketi: support
+      deploy-heketi: dc
     annotations:
       description: Defines how to deploy Heketi
   spec:
     replicas: 1
     selector:
-      name: deploy-heketi
+      deploy-heketi: pod
     triggers:
     - type: ConfigChange
     strategy:
@@ -60,9 +58,8 @@ objects:
       metadata:
         name: deploy-heketi
         labels:
-          name: deploy-heketi
           glusterfs: heketi-pod
-          deploy-heketi: support
+          deploy-heketi: pod
       spec:
         serviceAccountName: heketi-service-account
         containers:

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -26,6 +26,7 @@ objects:
       metadata:
         name: glusterfs
         labels:
+          glusterfs: pod
           glusterfs-node: pod
       spec:
         nodeSelector:

--- a/deploy/ocp-templates/heketi-service-account.yaml
+++ b/deploy/ocp-templates/heketi-service-account.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: heketi-service-account
+  labels:
+    glusterfs: heketi-sa
+    heketi: sa

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -5,11 +5,10 @@ metadata:
   name: heketi
   labels:
     glusterfs: heketi-template
+    heketi: template
   annotations:
     description: Heketi service deployment template
     tags: glusterfs,heketi
-labels:
-  template: heketi
 objects:
 - kind: Service
   apiVersion: v1
@@ -17,6 +16,7 @@ objects:
     name: heketi
     labels:
       glusterfs: heketi-service
+      heketi: service
     annotations:
       description: Exposes Heketi service
   spec:
@@ -25,13 +25,14 @@ objects:
       port: 8080
       targetPort: 8080
     selector:
-      glusterfs: heketi-pod
+      heketi: pod
 - kind: Route
   apiVersion: v1
   metadata:
     name: heketi
     labels:
       glusterfs: heketi-route
+      heketi: route
   spec:
     to:
       kind: Service
@@ -42,12 +43,13 @@ objects:
     name: heketi
     labels:
       glusterfs: heketi-dc
+      heketi: dc
     annotations:
       description: Defines how to deploy Heketi
   spec:
     replicas: 1
     selector:
-      glusterfs: heketi-pod
+      heketi: pod
     triggers:
     - type: ConfigChange
     strategy:
@@ -57,6 +59,7 @@ objects:
         name: heketi
         labels:
           glusterfs: heketi-pod
+          heketi: pod
       spec:
         serviceAccountName: heketi-service-account
         containers:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -37,14 +37,6 @@ If you are not able to deploy a hyper-converged GlusterFS cluster, you must
 have one running somewhere that the Kubernetes nodes can access. The above
 requirements still apply for any pre-existing GlusterFS cluster.
 
-## Client Setup
-
-Heketi provides a CLI client that allows users to administer the deployment
-and configuration of GlusterFS in Kubernetes. Download and install
-[heketi-cli](https://github.com/heketi/heketi/releases) onto a client machine
-that has administrative access to your Kubernetes cluster. This same machine
-will be the one you use for deployment.
-
 ## Deployment Overview
 
 An administrator must provide the topology information of the GlusterFS cluster
@@ -92,8 +84,6 @@ administrative access to your Kubernetes cluster. You should familiarize
 yourself with the script's options by running `gk-deploy -h`. Some things to
 note when running the script:
 
- * It must be run on a machine with `heketi-cli` installed.
-
  * By default it expects the topology file to be in the same directory as
  itself. You can specify a different location as the first non-option
  argument on the command-line.
@@ -115,7 +105,8 @@ note when running the script:
 # Usage Examples
 
 Running the following from a node with Kubernetes administrative access and
-`heketi-cli` installed creates 100GB Persistent Volume
+[heketi-cli](https://github.com/heketi/heketi/releases) installed creates a
+100GB Persistent Volume
 [which can be claimed](http://kubernetes.io/docs/user-guide/persistent-volumes/#claims-as-volumes)
 from any application:
 

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -1,35 +1,42 @@
-- name: kubeadm init
-  command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kubernetes_version }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+- name: check for kubelet config
+  stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: kubelet
 
-- name: create root kube dir
-  file:
-    path: /root/.kube
-    state: directory
-    owner: root
-    group: root
+- block:
+  - name: kubeadm init
+    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kubernetes_version }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
 
-- name: create root kube config
-  copy:
-    src: /etc/kubernetes/admin.conf
-    dest: /root/.kube/config
-    remote_src: True
-    owner: root
-    group: root
+  - name: create root kube dir
+    file:
+      path: /root/.kube
+      state: directory
+      owner: root
+      group: root
 
-- name: create user kube dir
-  file:
-    path: /home/vagrant/.kube
-    state: directory
-    owner: vagrant
-    group: vagrant
+  - name: create root kube config
+    copy:
+      src: /etc/kubernetes/admin.conf
+      dest: /root/.kube/config
+      remote_src: True
+      owner: root
+      group: root
 
-- name: create user kube config
-  copy:
-    src: /etc/kubernetes/admin.conf
-    dest: /home/vagrant/.kube/config
-    remote_src: True
-    owner: vagrant
-    group: vagrant
+  - name: create user kube dir
+    file:
+      path: /home/vagrant/.kube
+      state: directory
+      owner: vagrant
+      group: vagrant
+
+  - name: create user kube config
+    copy:
+      src: /etc/kubernetes/admin.conf
+      dest: /home/vagrant/.kube/config
+      remote_src: True
+      owner: vagrant
+      group: vagrant
+  when: not kubelet.stat.exists
 
 - name: create weave network
   command: kubectl apply -f https://git.io/weave-kube-1.6

--- a/vagrant/roles/nodes/tasks/main.yml
+++ b/vagrant/roles/nodes/tasks/main.yml
@@ -1,6 +1,8 @@
 - name: establish route for 10.96.0.0/16
   command: ip route add 10.96.0.0/16 dev eth1 src {{ hostvars[item].ansible_eth1.ipv4.address }}
   with_items: "{{ ansible_hostname }}"
+  register: route_add
+  failed_when: route_add.rc != 0 and "File exists" not in route_add.stderr
 
 - name: Open port 24007 (GlusterFS daemon)
   firewalld: port=24007/tcp zone=trusted permanent=true state=enabled immediate=true
@@ -31,43 +33,51 @@
 - name: clean up kubernetes /etc directory
   file: path=/etc/kubernetes/manifests state=absent
 
-- name: kubeadm join with master
-  command: kubeadm join --skip-preflight-checks --token={{ kubernetes_token }} {{ hostvars['master'].ansible_eth1.ipv4.address }}:6443
+- name: check for kubelet config
+  stat:
+    path: /etc/kubernetes/kubelet.conf
+  register: kubelet
 
-- name: create root kube dir on node
-  file:
-    path: /root/.kube
-    state: directory
-    owner: root
-    group: root
+- block:
+  - name: kubeadm join with master
+    command: kubeadm join --skip-preflight-checks --token={{ kubernetes_token }} {{ hostvars['master'].ansible_eth1.ipv4.address }}:6443
 
-- name: create root kube config on node
-  copy:
-    src: /etc/kubernetes/kubelet.conf
-    dest: /root/.kube/config
-    remote_src: True
-    owner: root
-    group: root
+  - name: create root kube dir on node
+    file:
+      path: /root/.kube
+      state: directory
+      owner: root
+      group: root
+    when: not kubelet.stat.exists
 
-- name: create user kube dir on node
-  file:
-    path: /home/vagrant/.kube
-    state: directory
-    owner: vagrant
-    group: vagrant
+  - name: create root kube config on node
+    copy:
+      src: /etc/kubernetes/kubelet.conf
+      dest: /root/.kube/config
+      remote_src: True
+      owner: root
+      group: root
 
-- name: create user kube config on node
-  copy:
-    src: /etc/kubernetes/kubelet.conf
-    dest: /home/vagrant/.kube/config
-    remote_src: True
-    owner: vagrant
-    group: vagrant
+  - name: create user kube dir on node
+    file:
+      path: /home/vagrant/.kube
+      state: directory
+      owner: vagrant
+      group: vagrant
 
-- name: wait for node to be ready
-  shell: test "$(kubectl get nodes {{ ansible_hostname }} --no-headers | awk '{ print $2 }')" = "Ready"
-  register: task_result
-  until: task_result.rc == 0
-  delay: 10
-  retries: 30
-  changed_when: false
+  - name: create user kube config on node
+    copy:
+      src: /etc/kubernetes/kubelet.conf
+      dest: /home/vagrant/.kube/config
+      remote_src: True
+      owner: vagrant
+      group: vagrant
+
+  - name: wait for node to be ready
+    shell: test "$(kubectl get nodes {{ ansible_hostname }} --no-headers | awk '{ print $2 }')" = "Ready"
+    register: task_result
+    until: task_result.rc == 0
+    delay: 10
+    retries: 30
+    changed_when: false
+  when: not kubelet.stat.exists


### PR DESCRIPTION
This PR allows for gk-deploy to be rerun in the same environment and continue from where it determines to be where it left off. It also removes the default behavior to abort on error, allowing for faster troubleshooting of a failed environment and introducing the ability to manually fix it before rerunning the script to continue. This also removes the need for the `--load` parameter. Finally, I removed the requirement of having `heketi-cli` installed, opting to use the one in the heketi pods instead.

Note that this does not resolve the problem that we have where we can not recover from an inconsistent or corrupt heketi database. If this happens after the topology has been loaded, the user has no recourse but to run `-g --abort` and wipe the GlusterFS storage.

This PR also includes a few minor fixes I found along the way, mostly because I wanted to isolate the changes specific to the idempotent run introduction.

Depends on #281, #297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/289)
<!-- Reviewable:end -->
