### PR TITLE
gk-deploy: fix failure to run in testsuite

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 PROG="$(basename "${0}")"
-SCRIPT_DIR="$(dirname "$(realpath "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 TOPOLOGY='topology.json'
 LOG_FILE=''
 VERBOSE=0


### PR DESCRIPTION
regression introduced by the patch to make
gk-deploy runnable everywhere...
Can't use realpath in the travis CI test env.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/317)
<!-- Reviewable:end -->
