### PR TITLE
Fix selftests in CI by removing realpath

### DIFF
--- a/tests/complex/lib.sh
+++ b/tests/complex/lib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # honor variables set from the caller:
-: "${TEST_DIR="$(realpath "$(dirname "${0}")")"}"
+: "${TEST_DIR="$(dirname "${0}")"}"
 : "${BASE_DIR="${TEST_DIR}/../.."}"
 : "${VAGRANT_DIR="${BASE_DIR}/vagrant"}"
 : "${DEPLOY_DIR="${BASE_DIR}/deploy"}"
@@ -204,7 +204,7 @@ run() {
 		fi
 		shift
 	done
-	script=$(realpath "${1%% *}")
+	script="${1%% *}"
         args=${1#* }
 	shift
 

--- a/tests/complex/run.sh
+++ b/tests/complex/run.sh
@@ -2,7 +2,7 @@
 
 # shellcheck disable=SC2034
 TESTNAME=""
-TEST_DIR="$(realpath "$(dirname "${0}")")"
+TEST_DIR="$(dirname "${0}")"
 
 source "${TEST_DIR}/lib.sh"
 

--- a/tests/complex/test-dynamic-provisioning.sh
+++ b/tests/complex/test-dynamic-provisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR="$(realpath "$(dirname "${0}")")"
+TEST_DIR="$(dirname "${0}")"
 DOCKER_IMAGE="gcr.io/google_containers/nginx-slim:0.8"
 
 source "${TEST_DIR}/lib.sh"

--- a/tests/complex/test-gk-deploy.sh
+++ b/tests/complex/test-gk-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR="$(realpath "$(dirname "${0}")")"
+TEST_DIR="$(dirname "${0}")"
 
 source "${TEST_DIR}/lib.sh"
 

--- a/tests/complex/test-setup.sh
+++ b/tests/complex/test-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR="$(realpath "$(dirname "${0}")")"
+TEST_DIR="$(dirname "${0}")"
 
 source "${TEST_DIR}/lib.sh"
 

--- a/tests/complex/test-teardown.sh
+++ b/tests/complex/test-teardown.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR="$(realpath "$(dirname "${0}")")"
+TEST_DIR="$(dirname "${0}")"
 
 source "${TEST_DIR}/lib.sh"
 

--- a/tests/simple/common/shell_tests.sh
+++ b/tests/simple/common/shell_tests.sh
@@ -11,3 +11,11 @@ test_shellcheck() {
 	shellcheck -x -s bash -e SC2181,SC2029,SC1091,SC1090 "${1}"
 }
 
+test_real_path() {
+	grep -s "[r]ealpath" "${1}"
+	if [[ ${?} -eq 0 ]]; then
+		return 1
+	else
+		return 0
+	fi
+}

--- a/tests/simple/gk-deploy/run.sh
+++ b/tests/simple/gk-deploy/run.sh
@@ -4,9 +4,14 @@ SCRIPT_DIR="$(dirname "${0}")"
 
 echo "running tests in ${SCRIPT_DIR}"
 
+failed=0
+
 for test in ${SCRIPT_DIR}/test_*.sh ; do
 	$test
-	if [ $? -ne 0 ]; then
-		exit 1
+	rc=${?}
+	if [[ ${rc} -ne 0 ]]; then
+		((failed+=rc))
 	fi
 done
+
+exit ${failed}

--- a/tests/simple/gk-deploy/run.sh
+++ b/tests/simple/gk-deploy/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(realpath "$(dirname "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 
 echo "running tests in ${SCRIPT_DIR}"
 

--- a/tests/simple/gk-deploy/test_gk_deploy_basic.sh
+++ b/tests/simple/gk-deploy/test_gk_deploy_basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(realpath "$(dirname "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 STUBS_DIR="${SCRIPT_DIR}/stubs"
 TESTS_DIR="${SCRIPT_DIR}/.."
 INC_DIR="${TESTS_DIR}/common"

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -2,6 +2,8 @@
 
 SCRIPT_DIR="$(dirname "${0}")"
 
+failed=0
+
 for testdir in ${SCRIPT_DIR}/*; do
 	if [[ ! -d ${testdir} ]]; then
 		continue
@@ -17,6 +19,8 @@ for testdir in ${SCRIPT_DIR}/*; do
 	popd
 
 	if [[ ${rc} -ne 0 ]]; then
-		exit 1
+		((failed+=rc))
 	fi
 done
+
+exit ${failed}

--- a/tests/simple/run.sh
+++ b/tests/simple/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(realpath "$(dirname "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 
 for testdir in ${SCRIPT_DIR}/*; do
 	if [[ ! -d ${testdir} ]]; then

--- a/tests/simple/shell/run.sh
+++ b/tests/simple/shell/run.sh
@@ -4,6 +4,14 @@ SCRIPT_DIR=$(cd "$(dirname "${0}")" || exit 1; pwd)
 
 echo "running tests in ${SCRIPT_DIR}"
 
+failed=0
+
 for test in ${SCRIPT_DIR}/test_*.sh; do
 	${test}
+	rc=${?}
+	if [[ ${rc} -ne 0 ]]; then
+		((failed+=rc))
+	fi
 done
+
+exit ${failed}

--- a/tests/simple/shell/test_realpath.sh
+++ b/tests/simple/shell/test_realpath.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(cd "$(dirname "${0}")" || exit 1; pwd)
+TESTS_DIR="${SCRIPT_DIR}/.."
+INC_DIR="${TESTS_DIR}/common"
+BASE_DIR="${SCRIPT_DIR}/../../.."
+
+source "${INC_DIR}/subunit.sh"
+source "${INC_DIR}/shell_tests.sh"
+
+failed=0
+
+while read -r script; do
+	# note: this is intentially mis-spelled realPath
+	# so that this does not trigger an error.
+	testit "check for use of realPath: $(basename "${script}")" \
+		test_real_path "${script}" \
+		|| ((failed++))
+done <<< "$(find "${BASE_DIR}" -name "*.sh" | grep -v "subunit.sh")"
+
+testok "${0}" "${failed}"

--- a/tests/simple/yaml/run.sh
+++ b/tests/simple/yaml/run.sh
@@ -4,6 +4,14 @@ SCRIPT_DIR="$(dirname "${0}")"
 
 echo "running tests in ${SCRIPT_DIR}"
 
+failed=0
+
 for test in ${SCRIPT_DIR}/test_*.sh ; do
 	${test}
+	rc=${?}
+	if [[ ${?} -ne 0 ]]; then
+		((failed+=rc))
+	fi
 done
+
+exit ${failed}

--- a/tests/simple/yaml/run.sh
+++ b/tests/simple/yaml/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(realpath "$(dirname "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 
 echo "running tests in ${SCRIPT_DIR}"
 

--- a/tests/simple/yaml/test_syntax.sh
+++ b/tests/simple/yaml/test_syntax.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(realpath "$(dirname "${0}")")"
+SCRIPT_DIR="$(dirname "${0}")"
 TESTS_DIR="${SCRIPT_DIR}/.."
 INC_DIR="${TESTS_DIR}/common"
 BASE_DIR="${SCRIPT_DIR}/../../.."

--- a/vagrant/demo/demo-deploy.sh
+++ b/vagrant/demo/demo-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 
 . "${DEMO_DIR}/util.sh"

--- a/vagrant/demo/demo-dynamic-provisioning.sh
+++ b/vagrant/demo/demo-dynamic-provisioning.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 
 cd "${VAGRANT_DIR}" || exit 1

--- a/vagrant/demo/demo-inside-wrapper.sh
+++ b/vagrant/demo/demo-inside-wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 SSH_CONFIG=${DEMO_DIR}/ssh-config
 

--- a/vagrant/demo/demo-prepare.sh
+++ b/vagrant/demo/demo-prepare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 DEPLOY_DIR="${VAGRANT_DIR}/../deploy"
 SSH_CONFIG="${DEMO_DIR}/ssh-config"

--- a/vagrant/demo/demo-status.sh
+++ b/vagrant/demo/demo-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 
 cd "${VAGRANT_DIR}" || exit 1

--- a/vagrant/demo/demo-test-heketi.sh
+++ b/vagrant/demo/demo-test-heketi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEMO_DIR="$(realpath "$(dirname "${0}")")"
+DEMO_DIR="$(dirname "${0}")"
 VAGRANT_DIR="${DEMO_DIR}/.."
 
 cd "${VAGRANT_DIR}" || exit 1

--- a/vagrant/demo/util.sh
+++ b/vagrant/demo/util.sh
@@ -58,12 +58,6 @@ function run() {
     return ${r}
 }
 
-function relative() {
-    for arg; do
-        echo "$(realpath "$(dirname "$(which "${0}")")")/${arg}" | sed "s|$(realpath "$(pwd)")|.|"
-    done
-}
-
 #SSH_NODE=$(kubectl get nodes | tail -1 | cut -f1 -d' ')
 
 trap "echo" EXIT


### PR DESCRIPTION
Realpath is not available in travis CI.
The bad thing is that these errors got unnoticed.
* So this removes the uses of realpath.
* And it adds a test to make sure that realpath is not used...
* Finally, (this could be put into a separate PR), this fixes the simple testsuite to do proper error propagation. (Previously, errors could go unnoticed even if the test itself detected it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/319)
<!-- Reviewable:end -->
