### PR TITLE
gk-deploy: Set resource requests for GlusterFS pod

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -23,6 +23,10 @@ spec:
       - image: gluster/gluster-centos:latest
         imagePullPolicy: IfNotPresent
         name: glusterfs
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 100m
         volumeMounts:
         - name: glusterfs-heketi
           mountPath: "/var/lib/heketi"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -36,6 +36,10 @@ objects:
         - image: gluster/gluster-centos:latest
           imagePullPolicy: IfNotPresent
           name: glusterfs
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 100m
           volumeMounts:
           - name: glusterfs-heketi
             mountPath: "/var/lib/heketi"
@@ -84,7 +88,6 @@ objects:
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 15
-          resources: {}
           terminationMessagePath: "/dev/termination-log"
         volumes:
         - name: glusterfs-heketi


### PR DESCRIPTION
A followup to #214, based on discussions therein. This configuration sets the GlusterFS pod to the "Burstable" QoS tier. More information [here](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/).

I am open to debate on more reasonable request values, as long as the memory request stays under `1Gi`. :)

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/324)
<!-- Reviewable:end -->
