### PR TITLE
gk-deploy: Change container directory of heketi-storage.json

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -745,7 +745,7 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
   fi
 
   if [[ $("${heketi_cli}" volume list 2>&1) != *heketidbstorage* ]]; then
-    eval_output "${heketi_cli} setup-openshift-heketi-storage 2>&1"
+    eval_output "${heketi_cli} setup-openshift-heketi-storage --listfile=/tmp/heketi-storage.json 2>&1"
     if [[ ${?} != 0 ]]; then
       output "Failed on setup openshift heketi storage"
       output "This may indicate that the storage must be wiped and the GlusterFS nodes must be reset."
@@ -756,7 +756,7 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     exit 1
   fi
 
-  eval_output "${CLI} exec -it ${heketi_pod} -- cat heketi-storage.json | ${CLI} create -f - 2>&1"
+  eval_output "${CLI} exec -it ${heketi_pod} -- cat /tmp/heketi-storage.json | ${CLI} create -f - 2>&1"
   if [[ ${?} != 0 ]]; then
     output "Failed on creating heketi storage resources."
     exit 1


### PR DESCRIPTION
If the image is more securely configured, heketi-cli doesn't have write
permissions to the root of the filesystem of the container. Changed the
output location to /tmp.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/325)
<!-- Reviewable:end -->
