### PR TITLE
Don't try to forward terminal to `kubectl exec` calls

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -726,7 +726,7 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
   fi
 
   heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" 2>&1 | awk '{print $1}')
-  heketi_cli="${CLI} exec -it ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
+  heketi_cli="${CLI} exec -i ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
 
   load_temp=$(mktemp)
   eval_output "${heketi_cli} topology load --json=/etc/heketi/topology.json 2>&1" | tee "${load_temp}"
@@ -756,7 +756,7 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     exit 1
   fi
 
-  eval_output "${CLI} exec -it ${heketi_pod} -- cat /tmp/heketi-storage.json | ${CLI} create -f - 2>&1"
+  eval_output "${CLI} exec -i ${heketi_pod} -- cat /tmp/heketi-storage.json | ${CLI} create -f - 2>&1"
   if [[ ${?} != 0 ]]; then
     output "Failed on creating heketi storage resources."
     exit 1
@@ -827,7 +827,7 @@ administrative commands you can install 'heketi-cli' and use it as follows:
 You can find it at https://github.com/heketi/heketi/releases . Alternatively,
 use it from within the heketi pod:
 
-  # ${CLI} exec -it <HEKETI_POD> -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
+  # ${CLI} exec -i <HEKETI_POD> -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
 
 For dynamic provisioning, create a StorageClass similar to this:
 


### PR DESCRIPTION
If run not from terminal, kubectl shows this error:

  Unable to use a TTY - input is not a terminal or the right kind of file

It makes the script think that topology loading failed and exit with
error:

  Error loading the cluster topology.

That said we don't need to forward terminal here at all - we call CLI
that doesn't interact with terminal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/329)
<!-- Reviewable:end -->
