### PR TITLE
Don't add stderr to stdout when parsing `kubectl get pod` output

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -298,7 +298,7 @@ check() {
       break
     fi
     sleep 2
-    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2> /dev/null)
+    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2>/dev/null)
     if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
       reslines=$(echo "$res" | wc -l)
       ((reslines+=1))

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -298,7 +298,7 @@ check() {
       break
     fi
     sleep 2
-    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2>&1)
+    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}")
     if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
       reslines=$(echo "$res" | wc -l)
       ((reslines+=1))
@@ -725,7 +725,7 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     debug "OK"
   fi
 
-  heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" 2>&1 | awk '{print $1}')
+  heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" | awk '{print $1}')
   heketi_cli="${CLI} exec -it ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
 
   load_temp=$(mktemp)

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -298,7 +298,7 @@ check() {
       break
     fi
     sleep 2
-    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}")
+    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2> /dev/null)
     if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
       reslines=$(echo "$res" | wc -l)
       ((reslines+=1))


### PR DESCRIPTION
Due to issue in kubectl ( kubernetes/kubernetes#48924 ) it outputs some
warnings to stderr and they are considered to be output lines and it
breaks the script in 2 places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/330)
<!-- Reviewable:end -->
