### PR TITLE
Added new env. variable GB_GLFS_LRU_COUNT for indicating maximum number

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -23,6 +23,9 @@ spec:
       - image: gluster/gluster-centos:latest
         imagePullPolicy: IfNotPresent
         name: glusterfs
+        env:
+        - name: GB_GLFS_LRU_COUNT
+          value: 15
         resources:
           requests:
             memory: 100Mi

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -36,6 +36,9 @@ objects:
         - image: gluster/gluster-centos:latest
           imagePullPolicy: IfNotPresent
           name: glusterfs
+          env:
+          - name: GB_GLFS_LRU_COUNT
+            value: "${GB_GLFS_LRU_COUNT}"
           resources:
             requests:
               memory: 100Mi
@@ -128,3 +131,8 @@ parameters:
   displayName: Daemonset Storage Node Label
   description: This is the value that will be used for the storagenode label in the daemonset node selector.
   value: glusterfs
+- name: GB_GLFS_LRU_COUNT
+  displayName: Maximum number of block hosting volumes
+  description: This value is to set maximum number of block hosting volumes.
+  value: "15"
+  required: true


### PR DESCRIPTION
Added new env. variable GB_GLFS_LRU_COUNT for indicating maximum number
of block hosting volumes.

Signed-off-by: Saravanakumar <sarumuga@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/335)
<!-- Reviewable:end -->
