### PR TITLE
vagrant: make it a little more easy to use the created local registry

### DIFF
--- a/vagrant/global_vars.yml
+++ b/vagrant/global_vars.yml
@@ -35,7 +35,7 @@ install_pkgs:
 #   Valid values are 'present' and 'absent'. (default 'present')
 # * gcr_proxy_nginx: The version of nginx-slim to use for the gcr.io proxy.
 #   (default '0.8')
-#custom_registry: 192.168.121.1:5000
+#custom_registry: 192.168.10.1:5000
 #custom_registry_insecure: false
 #custom_registry_add: false
 #custom_registry_gcr: true


### PR DESCRIPTION
Have the commented out value match the ip address that we use
for the vagrant boxes, so that in case we use docker-registry-run.sh
to create the registry, we just need to comment out the line
to make use of it.

Signed-off-by: Michael Adam <obnox@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/336)
<!-- Reviewable:end -->
