### PR TITLE
Fix TCMU log directory name as TCMU_LOGDIR

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         env:
         - name: GB_GLFS_LRU_COUNT
           value: 15
-        - name: TCMU_LOG_DIR
+        - name: TCMU_LOGDIR
           value: "/var/log/glusterfs/gluster-block"
         resources:
           requests:

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -39,8 +39,8 @@ objects:
           env:
           - name: GB_GLFS_LRU_COUNT
             value: "${GB_GLFS_LRU_COUNT}"
-          - name: TCMU_LOG_DIR
-            value: "${TCMU_LOG_DIR}"
+          - name: TCMU_LOGDIR
+            value: "${TCMU_LOGDIR}"
           resources:
             requests:
               memory: 100Mi
@@ -138,7 +138,7 @@ parameters:
   description: This value is to set maximum number of block hosting volumes.
   value: "15"
   required: true
-- name: TCMU_LOG_DIR
+- name: TCMU_LOGDIR
   displayName: Tcmu runner log directory
   description: This value is to set tcmu runner log directory
   value: "/var/log/glusterfs/gluster-block"


### PR DESCRIPTION
Fix TCMU log directory name as TCMU_LOGDIR

Signed-off-by: Saravanakumar <sarumuga@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/344)
<!-- Reviewable:end -->
