### PR TITLE
when using ssh executor provide /etc/fstab as ENV

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -34,6 +34,7 @@ EXISTS_DEPLOY_HEKETI=0
 EXISTS_HEKETI=0
 EXISTS_OBJECT=0
 EXECUTOR="kubernetes"
+FSTAB="/var/lib/heketi/fstab"
 SSH_KEYFILE="/dev/null"
 SSH_USER="root"
 SSH_SUDO="false"
@@ -393,6 +394,7 @@ while [[ $# -ge 1 ]]; do
         ;;
         s*|-ssh-keyfile)
         EXECUTOR="ssh"
+        FSTAB="/etc/fstab"
         SSH_KEYFILE=$(assign "${key:${keypos}}" "${2}")
         if [[ $? -eq 2 ]]; then shift; fi
         keypos=$keylen
@@ -751,14 +753,14 @@ if [[ ${GLUSTER} -eq 1 ]] && [[ ${EXISTS_GLUSTERFS} -eq 0 ]] && [[ ${EXISTS_HEKE
 fi
 
 if [[ ${EXISTS_DEPLOY_HEKETI} -eq 0 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
-  sed -e "s/\${HEKETI_EXECUTOR}/${EXECUTOR}/" -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" "${SCRIPT_DIR}/heketi.json.template" > heketi.json
+  sed -e "s/\${HEKETI_EXECUTOR}/${EXECUTOR}/" -e "s/\${HEKETI_FSTAB}/${FSTAB}/" -e "s/\${SSH_PORT}/${SSH_PORT}/" -e "s/\${SSH_USER}/${SSH_USER}/" -e "s/\${SSH_SUDO}/${SSH_SUDO}/" "${SCRIPT_DIR}/heketi.json.template" > heketi.json
   eval_output "${CLI} create secret generic heketi-config-secret --from-file=private_key=${SSH_KEYFILE} --from-file=./heketi.json --from-file=topology.json=${TOPOLOGY}"
   eval_output "${CLI} label --overwrite secret heketi-config-secret glusterfs=heketi-config-secret heketi=config-secret"
   rm -f heketi.json
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
+    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} HEKETI_FSTAB=${FSTAB} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} deploy-heketi | ${CLI} create -f - 2>&1"
   else
-    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
+    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_FSTAB}/${FSTAB}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/deploy-heketi-deployment.yaml | ${CLI} create -f - 2>&1"
   fi
 
   output -n "Waiting for deploy-heketi pod to start ... "
@@ -852,9 +854,9 @@ fi
 
 if [[ ${EXISTS_HEKETI} -eq 0 ]]; then
   if [[ "${CLI}" == *oc\ * ]]; then
-    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
+    eval_output "${CLI} process ${OC_PROCESS_VAL_SWITCH} HEKETI_EXECUTOR=${EXECUTOR} HEKETI_FSTAB=${FSTAB} ${OC_PROCESS_VAL_SWITCH} HEKETI_ADMIN_KEY=${ADMIN_KEY} ${OC_PROCESS_VAL_SWITCH} HEKETI_USER_KEY=${USER_KEY} heketi | ${CLI} create -f - 2>&1"
   else
-    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
+    eval_output "sed -e 's/\\\${HEKETI_EXECUTOR}/${EXECUTOR}/' -e 's/\\\${HEKETI_FSTAB}/${FSTAB}/' -e 's/\\\${HEKETI_ADMIN_KEY}/${ADMIN_KEY}/' -e 's/\\\${HEKETI_USER_KEY}/${USER_KEY}/' ${TEMPLATES}/heketi-deployment.yaml | ${CLI} create -f - 2>&1"
   fi
 
   output -n "Waiting for heketi pod to start ... "

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: HEKETI_EXECUTOR
           value: ${HEKETI_EXECUTOR}
         - name: HEKETI_FSTAB
-          value: "/var/lib/heketi/fstab"
+          value: ${HEKETI_FSTAB}
         - name: HEKETI_SNAPSHOT_LIMIT
           value: '14'
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: HEKETI_EXECUTOR
           value: ${HEKETI_EXECUTOR}
         - name: HEKETI_FSTAB
-          value: "/var/lib/heketi/fstab"
+          value: ${HEKETI_FSTAB}
         - name: HEKETI_SNAPSHOT_LIMIT
           value: '14'
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET

--- a/deploy/ocp-templates/deploy-heketi-template.yaml
+++ b/deploy/ocp-templates/deploy-heketi-template.yaml
@@ -73,7 +73,7 @@ objects:
           - name: HEKETI_EXECUTOR
             value: ${HEKETI_EXECUTOR}
           - name: HEKETI_FSTAB
-            value: /var/lib/heketi/fstab
+            value: ${HEKETI_FSTAB}
           - name: HEKETI_SNAPSHOT_LIMIT
             value: '14'
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
@@ -113,3 +113,7 @@ parameters:
   displayName: heketi executor type
   description: Set the executor type, kubernetes or ssh
   value: kubernetes
+- name: HEKETI_FSTAB
+  displayName: heketi fstab path
+  description: Set the fstab path, file that is populated with bricks that heketi creates
+  value: /var/lib/heketi/fstab

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -74,7 +74,7 @@ objects:
           - name: HEKETI_EXECUTOR
             value: ${HEKETI_EXECUTOR}
           - name: HEKETI_FSTAB
-            value: /var/lib/heketi/fstab
+            value: ${HEKETI_FSTAB}
           - name: HEKETI_SNAPSHOT_LIMIT
             value: '14'
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
@@ -117,3 +117,7 @@ parameters:
   displayName: heketi executor type
   description: Set the executor type, kubernetes or ssh
   value: kubernetes
+- name: HEKETI_FSTAB
+  displayName: heketi fstab path
+  description: Set the fstab path, file that is populated with bricks that heketi creates
+  value: /var/lib/heketi/fstab


### PR DESCRIPTION
If ssh executor is used, it also generally means that Gluster is not
containerized. In such instances, we don't have the startup script in
Gluster container which would look at /var/lib/heketi/fstab for bricks.
Hence, this patch changes the HEKETI_FSTAB ENV to /etc/fstab when
sshexec is chosen.

For now, this is sufficient. When and if we want to support ssh access
to Gluster containers, we will have to provide a flag --fstab to let
users decide where the file should reside. Not now.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/351)
<!-- Reviewable:end -->
