### PR TITLE
fix SC2199 in tests/simple/gk-deploy/stubs/cli.sh

### DIFF
--- a/tests/simple/gk-deploy/stubs/cli.sh
+++ b/tests/simple/gk-deploy/stubs/cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${@}" == *"get "* ]]; then
+if [[ "${*}" == *"get "* ]]; then
 	while [[ "${1}" != "get" ]]; do
 		shift
 	done
@@ -14,7 +14,7 @@ if [[ "${@}" == *"get "* ]]; then
 	if [[ "${restype}" == namespace* ]] && [[ "${select}" == "invalid" ]]; then
 		echo "Error"
 	fi
-elif [[ "${@}" == *" config get-contexts" ]]; then
+elif [[ "${*}" == *" config get-contexts" ]]; then
 	if [[ "${0}" == *oc* ]]; then
 		echo "* two three four storage"
 	fi


### PR DESCRIPTION
As per information provided in
https://github.com/koalaman/shellcheck/wiki/SC2199, we need to use $*
instead of ${@} in cli.sh

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/352)
<!-- Reviewable:end -->
