### PR TITLE
vagrant: use kubernetes version 1.7.8

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -13,7 +13,7 @@ $ vagrant ssh master
 Works in Vagrant/Ansible on Linux with libvirt/KVM or on Mac OS X on Virtualbox
 
 ## Versions
-Currently it uses Kubernetes v1.6.1
+Currently it uses Kubernetes v1.7.8
 
 ## Features
 

--- a/vagrant/global_vars.yml
+++ b/vagrant/global_vars.yml
@@ -1,5 +1,5 @@
 ---
-kubernetes_version: 1.6.1
+kubernetes_version: 1.7.8
 kubernetes_token: abcdef.1234567890abcdef
 install_pkgs:
 - wget
@@ -12,9 +12,9 @@ install_pkgs:
 - iptables-utils
 - iptables-services
 - docker
-- kubeadm
-- kubelet
-- kubectl
+- kubeadm-1.7.8
+- kubelet-1.7.8
+- kubectl-1.7.8
 - ntp
 # The following variables control the use and configuration of a custom docker
 # registry:

--- a/vagrant/global_vars.yml
+++ b/vagrant/global_vars.yml
@@ -12,9 +12,9 @@ install_pkgs:
 - iptables-utils
 - iptables-services
 - docker
-- kubeadm-1.7.8
-- kubelet-1.7.8
-- kubectl-1.7.8
+- kubeadm-{{ kubernetes_version }}
+- kubelet-{{ kubernetes_version }}
+- kubectl-{{ kubernetes_version }}
 - ntp
 # The following variables control the use and configuration of a custom docker
 # registry:


### PR DESCRIPTION
Without specifying the Kubernetes version the playbooks fail due to
behavior changes in kubeadm and friends.
Explicitly ask for 1.7.8 as that is the newest version of 1.7 in the
google yum repo.

Signed-off-by: John Mulligan <jmulligan@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/373)
<!-- Reviewable:end -->
