### PR TITLE
vagrant: conditionalize ansible scripts to support alt. k8s versions

### DIFF
--- a/vagrant/global_vars.yml
+++ b/vagrant/global_vars.yml
@@ -1,6 +1,8 @@
 ---
-kubernetes_version: 1.7.8
+# Specify either "latest" or a version such as "1.7.10"
+kubernetes_version: latest
 kubernetes_token: abcdef.1234567890abcdef
+kubernetes_version_tag: "{% if kubernetes_version != 'latest' %}-{{ kubernetes_version }}{% endif %}"
 install_pkgs:
 - wget
 - screen
@@ -12,9 +14,9 @@ install_pkgs:
 - iptables-utils
 - iptables-services
 - docker
-- kubeadm-{{ kubernetes_version }}
-- kubelet-{{ kubernetes_version }}
-- kubectl-{{ kubernetes_version }}
+- kubeadm{{ kubernetes_version_tag }}
+- kubelet{{ kubernetes_version_tag }}
+- kubectl{{ kubernetes_version_tag }}
 - ntp
 # The following variables control the use and configuration of a custom docker
 # registry:

--- a/vagrant/roles/common/files/10-kubeadm-post-1.8.conf
+++ b/vagrant/roles/common/files/10-kubeadm-post-1.8.conf
@@ -1,0 +1,10 @@
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
+Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
+Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
+Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
+Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=systemd"
+ExecStart=
+#ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_EXTRA_ARGS $KUBELET_CGROUP_ARGS

--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -64,6 +64,10 @@
 - name: Ensure net.bridge.bridge-nf-call-iptables is set. See kubeadm
   copy: src=k8s.conf owner=root group=root dest=/etc/sysctl.d/k8s.conf
 
+- name: determine installed kubeadm version
+  command: rpm -q --qf '%{version}' kubeadm
+  register: kube_ver
+
 #- name: save iptables
 #  command: service iptables save
 
@@ -97,8 +101,23 @@
 - name: firewall trust port 9898
   firewalld: port=9898/tcp zone=trusted permanent=true state=enabled immediate=true
 
+# kubeadm 1.8+ does not like swap
+- block:
+  - name: disable current swaps
+    command: swapoff --all
+
+  - name: disable fstab swaps
+    mount:
+      state: absent
+      path: swap
+
+  - name: install fixed kubelet-kubeadm config file (1.8 and later)
+    copy: src=10-kubeadm-post-1.8.conf dest=/etc/systemd/system/kubelet.service.d/10-kubeadm.conf owner=root group=root mode=644 backup=yes
+  when: kube_ver.stdout | version_compare('1.8', '>=')
+
 - name: install fixed kubelet-kubeadm config file
   copy: src=10-kubeadm.conf dest=/etc/systemd/system/kubelet.service.d/ owner=root group=root mode=644 backup=yes
+  when: kube_ver.stdout | version_compare('1.8', '<')
 
 - name: copy docker conf
   template: src=docker.j2 dest=/etc/sysconfig/docker force=yes mode=0644

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - block:
   - name: kubeadm init
-    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kubernetes_version }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
 
   - name: create root kube dir
     file:
@@ -67,8 +67,9 @@
 - name: create weave network
   command: kubectl apply -f https://git.io/weave-kube-1.6
 
+# jsonpath tested with kubeadm 1.6, 1.7, 1.8 
 - name: get dns service address
-  shell: kubectl get services --all-namespaces | grep kube-dns | awk "{print \$3}"
+  command: kubectl get services --all-namespaces -ojsonpath='{.items[?(@.metadata.name=="kube-dns")].spec.clusterIP}'
   register: kubednsaddress
 
 - name: wait for dns to be ready

--- a/vagrant/roles/nodes/tasks/main.yml
+++ b/vagrant/roles/nodes/tasks/main.yml
@@ -55,6 +55,10 @@
       group: root
     when: not kubelet.stat.exists
 
+  - name: wait for kubelet to create kubernetes.conf file
+    wait_for:
+      path: /etc/kubernetes/kubelet.conf
+
   - name: create root kube config on node
     copy:
       src: /etc/kubernetes/kubelet.conf


### PR DESCRIPTION
Conditionalize various aspects of the ansible scripts in order to
support alternative Kubernetes versions. One can edit the
global_vars.yml and provide a value to "kubernetes_version" of either
"latest" or a version number such as "1.8.1", "1.7.8", etc.

Tested specifying: latest, 1.8.1, 1.7.8, 1.7.1, 1.6.11

Signed-off-by: John Mulligan <jmulligan@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/376)
<!-- Reviewable:end -->
