### PR TITLE
vagrant: add note to the main readme to indicate caching is possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ following pre-requisites on your machine:
 
 To spin up the cluster, simply run `./up.sh` in the `vagrant/` directory.
 
+***NOTE***: If you plan to run ./up.sh more than once the vagrant setup supports
+caching packages and container images. Please read the
+[vagrant directory README](./vagrant/README.md)
+for more information on how to configure and use the caching support.
+
 Next, copy the `deploy/` directory to the master node of the cluster.
 
 You will have to provide your own topology file. A sample topology file is


### PR DESCRIPTION
The quickstart guide is nice and straightforward but I didn't intially
realize caching was possible. This change adds a note in the quickstart
to indicate to readers that caching is possible and that one should
refer to the vagrant directory readme for that information.

I was a tad bit iffy on where to put the note so I'm willing to move
it to later in the quickstart if we think it interrupts the flow
of the text.

Signed-off-by: John Mulligan <jmulligan@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/379)
<!-- Reviewable:end -->
