### PR TITLE
Add additional support for caching in vagrant dir

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -68,3 +68,36 @@ Now Docker will pull gcr.io images and custom images from your custom registry,
 and check your custom registry before pulling from Docker Hub. You will want to
 periodically set `custom_registry_add=false` and `custom_registry_gcr=false` to
 pull updated images and then cache them with `docker-cache.sh`.
+
+**CUSTOM YUM REPOS:** As an alternative or complementary tool to the rpm caching
+feature mentioned above, the `custom_yum_repos` variable can be enabled to
+supply custom yum repos to the VMs. These custom repos can be used to cache
+packages across multiple projects or inject custom RPMs into the VMs.
+
+To configure it, uncomment or copy the `custom_yum_repos` variable in
+`global_vars.yml`. Supply key-value pairs, where the key is the name of the
+yum repository and the value is the repository's url. Example:
+  ```
+  custom_yum_repos:
+    kubernetes_el7: http://mypkgs/path/to/repo1
+    epel_el7: http://mypkgs/path/to/repo2
+    gluster_el7: http://mypkgs/another/repo/path/repo3
+  ```
+
+
+**CUSTOM HOST ALIASES:** If you want or need to use a name for the yum
+repository hosts or custom docker registry that does not resolve normally,
+you can define a `custom_host_aliases` in `global_vars.yml`. This value takes
+a list of items where each item is a mapping with the keys `addr`, an ip
+address, and `names`, a list of host names. Example:
+   ```
+   custom_host_aliases:
+     - addr: 192.168.122.164
+       names:
+         - myserver
+         - myserver.localdomain
+     - addr: 192.168.122.166
+       names:
+         - foo
+         - foo.example.org
+   ```

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,6 +4,7 @@
 NODES = 3
 DISKS = 3
 CACHE = false
+LIBVIRT_DISK_CACHE = "default"
 
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
@@ -26,6 +27,7 @@ Vagrant.configure("2") do |config|
         master.vm.provider :libvirt do |lv|
             lv.memory = 1024
             lv.cpus = 2
+            lv.volume_cache = LIBVIRT_DISK_CACHE
         end
 
         # View the documentation for the provider you're using for more
@@ -74,6 +76,7 @@ Vagrant.configure("2") do |config|
                     lv.storage :file, :device => "vd#{driverletters[d]}", :path => "atomic-disk-#{i}-#{d}.disk", :size => '1024G'
                     lv.memory = 1024
                     lv.cpus =2
+                    lv.volume_cache = LIBVIRT_DISK_CACHE
                 end
             end
         end

--- a/vagrant/global_vars.yml
+++ b/vagrant/global_vars.yml
@@ -19,7 +19,7 @@ install_pkgs:
 - kubectl{{ kubernetes_version_tag }}
 - ntp
 # The following variables control the use and configuration of a custom docker
-# registry:
+# registry and/or custom rpm repositories:
 # * custom_registry: Specifies and enables a custom registry (default none)
 # * custom_registry_insecure: Marks the custom registry as insecure. This is
 #   typically the case if you're running a local registry on your host machine
@@ -37,9 +37,33 @@ install_pkgs:
 #   Valid values are 'present' and 'absent'. (default 'present')
 # * gcr_proxy_nginx: The version of nginx-slim to use for the gcr.io proxy.
 #   (default '0.8')
+# * custom_yum_repos: Define custom yum repos as mapping of repo names
+#   (short strings) to repo urls. One or more repo must be specified if this
+#   option is enabled. Using this option will disable the normal user of
+#   the centos epel, centos gluster, and google kubernetes repos.
+# * custom_host_aliases: If the custom_repos or registry refer to hostnames
+#   that cannot be resolved normally a custom_host_aliases variable can be
+#   used to add specific entries to /etc/hosts.
 #custom_registry: 192.168.10.1:5000
 #custom_registry_insecure: false
 #custom_registry_add: false
 #custom_registry_gcr: true
 #gcr_proxy_state: absent
 #gcr_proxy_nginx: 0.23
+#custom_yum_repos:
+#  kubernetes_el7: http://mypkgs/path/to/repo1
+#  epel_el7: http://mypkgs/path/to/repo2
+#  gluster_el7: http://mypkgs/another/repo/path/repo3
+#custom_host_aliases:
+#  - addr: 192.168.122.164
+#    names:
+#      - mypkgs
+#      - mypkgs.localdomain
+#      - rpms.example.com
+#  - addr: 192.168.122.168
+#    names:
+#      - marble
+#  - addr: 192.168.122.169
+#    names:
+#      - jimmy
+#      - cricket

--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -38,20 +38,44 @@
   - cache_exists.stat.exists == True
   - vagrant_cache
 
-- name: install centos and epel repos
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-  - epel-release
-  - centos-release-gluster
+- name: customize hosts file
+  lineinfile: dest=/etc/hosts line="{{ item.addr }} {{ item.names | join(\" \") }}"
+  when: custom_host_aliases is defined
+  with_items: "{{ custom_host_aliases | default(omit) }}"
 
-- name: setup kubernetes repo
-  yum_repository:
-    name: kubernetes
-    description: Kubernetes
-    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-    enabled: yes
+- block:
+  # setup standard repos
+  - name: install centos and epel repos
+    yum:
+      name: "{{ item }}"
+      state: present
+    with_items:
+    - epel-release
+    - centos-release-gluster
+
+  - name: setup kubernetes repo
+    yum_repository:
+      name: kubernetes
+      description: Kubernetes
+      baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+      enabled: yes
+  when: custom_repos is not defined
+
+- block:
+  - name: setup custom yum repos
+    yum_repository:
+      name: "{{ item.key }}"
+      description: "Custom-Repo-{{ item.key }}"
+      baseurl: "{{ item.value }}"
+      enabled: yes
+    with_dict: "{{ custom_yum_repos }}"
+
+  - name: disable yum fastestmirror plugin
+    lineinfile:
+      path: /etc/yum/pluginconf.d/fastestmirror.conf
+      regexp: "^enabled="
+      line: enabled=0
+  when: custom_yum_repos is defined
 
 - name: install base packages
   yum:


### PR DESCRIPTION
* Adds a top level variable for vm disk caching types.
* Adds custom yum repos support for cross vm rpm caching
* Adds helper variable for /etc/hosts

Using the pulp system for caching rpms and docker images I observed some minor speedups of rpm and the gluster and heketi docker image install steps.

# Using defaults (no special caching)

Friday 27 October 2017  13:39:18 -0400 (0:00:00.011)       0:06:46.133
===============================================================================
common : install base packages ---------------------------------------- 115.18s
nodes : Pull GlusterFS Docker image ------------------------------------ 65.86s
master : wait for dns to be ready -------------------------------------- 46.47s
nodes : Pull heketi Docker image --------------------------------------- 42.65s
master : kubeadm init -------------------------------------------------- 38.73s
nodes : wait for node to be ready -------------------------------------- 33.84s
common : install centos and epel repos --------------------------------- 15.55s
nodes : wait for kubelet to create kubernetes.conf file ----------------- 8.35s
common : restart network ------------------------------------------------ 5.77s
common : enable kube services ------------------------------------------- 4.39s
master : install s3-curl depencendies ----------------------------------- 3.51s
master : create weave network ------------------------------------------- 1.49s
common : build hosts file ----------------------------------------------- 1.24s
master : get s3curl ----------------------------------------------------- 1.08s
Gathering Facts --------------------------------------------------------- 1.02s
common : Ensure firewalld.service --------------------------------------- 1.01s
common : firewall trust eth1 -------------------------------------------- 1.00s
Gathering Facts --------------------------------------------------------- 0.98s
Gathering Facts --------------------------------------------------------- 0.94s
common : configure dm_snapshot module ----------------------------------- 0.76s
Playbook run took 0 days, 0 hours, 6 minutes, 46 seconds

# Using pulp server for caching (rpms & docker)

Friday 27 October 2017  13:57:20 -0400 (0:00:00.011)       0:06:03.767
=============================================================================== 
common : install base packages ---------------------------------------- 109.47s
master : wait for dns to be ready -------------------------------------- 85.44s
nodes : wait for node to be ready -------------------------------------- 43.79s
master : kubeadm init -------------------------------------------------- 40.55s
nodes : Pull GlusterFS Docker image ------------------------------------ 12.95s
nodes : Pull heketi Docker image --------------------------------------- 12.44s
nodes : wait for kubelet to create kubernetes.conf file ---------------- 10.38s
common : install centos and epel repos ---------------------------------- 7.72s
common : restart network ------------------------------------------------ 5.75s
common : enable kube services ------------------------------------------- 4.31s
master : install s3-curl depencendies ----------------------------------- 2.94s
master : create weave network ------------------------------------------- 1.40s
common : build hosts file ----------------------------------------------- 1.27s
Gathering Facts --------------------------------------------------------- 1.09s
Gathering Facts --------------------------------------------------------- 1.03s
common : firewall trust eth1 -------------------------------------------- 1.01s
common : Ensure firewalld.service --------------------------------------- 1.00s
master : get s3curl ----------------------------------------------------- 0.95s
common : setup custom yum repos ----------------------------------------- 0.86s
Gathering Facts --------------------------------------------------------- 0.85s
Playbook run took 0 days, 0 hours, 6 minutes, 3 seconds


Note: I did not manage to cache gcr.io images so those were not part of my test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/380)
<!-- Reviewable:end -->
