### PR TITLE
vagrant: ./up.sh should use --no-parallel to prevent download issues

### DIFF
--- a/vagrant/up.sh
+++ b/vagrant/up.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# download the box(es) to prevent issues with parallel "vagrant up"
+BOXES=$(awk -F '"' '/config.vm.box/ {print $2}' Vagrantfile | sort -u)
+for BOX in ${BOXES}; do
+  if ! (vagrant boxes list | grep -q -e "^${BOX}[[:space:]]"); then
+    vagrant box add "${BOX}"
+  fi
+done
+
 export ANSIBLE_TIMEOUT=60
 vagrant up --no-provision "${@}" \
     && vagrant provision


### PR DESCRIPTION
When I run ./up.sh in a clean environment, at least one of the VMs does
not come up. The following error is then displayed:

    An error occurred while executing multiple actions in parallel.
    Any errors that occurred are shown below.

    An error occurred while executing the action on the 'node0'
    machine. Please handle this error then try again:

    The box 'centos/7' could not be found or
    could not be accessed in the remote catalog. If this is a private
    box on HashiCorp's Atlas, please verify you're logged in via
    `vagrant login`. Also, please double-check the name. The expanded
    URL and error message are shown below:

    URL: https://atlas.hashicorp.com/centos/7
    Error: Could not resolve host: atlas.hashicorp.com

By using `vagrant up --no-parallel ...` the box gets downloaded for the
first VM and the others are able to use it as well.

Suggested-by: Raghavendra Talur <rtalur@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/397)
<!-- Reviewable:end -->
