### PR TITLE
Added version matching requirement to docs

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -32,6 +32,10 @@ requirements:
  * Each node requires that the `mount.glusterfs` command is available. Under
   all Red Hat-based OSes this command is provided by the `glusterfs-fuse`
   package.
+  
+  * GlusterFS client version installed on nodes should be as close as possible
+   to the version of the server. To get installed versions run
+   `glusterfs --version` or `kubectl exec <pod> -- glusterfs --version`.
 
 If you are not able to deploy a hyper-converged GlusterFS cluster, you must
 have one running somewhere that the Kubernetes nodes can access. The above


### PR DESCRIPTION
See issue #392.

By default on Ubuntu 16.04 version of glusterfs-client do not match version of server which causes client crash on mount attempt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/409)
<!-- Reviewable:end -->
