### PR TITLE
Probe heketi service from deploy-heketi pod in k8s

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -798,11 +798,15 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     heketi_service=$(${CLI} describe svc/deploy-heketi | grep "Endpoints:" | awk '{print $2}')
   done
 
+  heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" | awk '{print $1}')
+
   if [[ "${CLI}" == *oc\ * ]]; then
     heketi_service=$(${CLI} describe routes/deploy-heketi | grep "Requested Host:" | awk '{print $3}')
+    hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
+   else
+    hello=$(${CLI} exec -i "${heketi_pod}" -- curl "http://${heketi_service}/hello" 2>/dev/null)
   fi
 
-  hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
   if [[ "${hello}" != "Hello from Heketi" ]]; then
     output "Failed to communicate with deploy-heketi service."
     if [[ "${CLI}" == *oc\ * ]]; then
@@ -813,7 +817,6 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     debug "OK"
   fi
 
-  heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="deploy-heketi" | awk '{print $1}')
   heketi_cli="${CLI} exec -i ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '${ADMIN_KEY}'"
 
   load_temp=$(mktemp)

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -896,11 +896,15 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
+heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')
+  hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
+else
+  hello=$(${CLI} exec -i "${heketi_pod}" -- curl "http://${heketi_service}/hello" 2>/dev/null)
 fi
 
-hello=$(curl "http://${heketi_service}/hello" 2>/dev/null)
 if [[ "${hello}" != "Hello from Heketi" ]]; then
   output "Failed to communicate with heketi service."
   if [[ "${CLI}" == *oc\ * ]]; then
@@ -918,7 +922,7 @@ administrative commands you can install 'heketi-cli' and use it as follows:
 You can find it at https://github.com/heketi/heketi/releases . Alternatively,
 use it from within the heketi pod:
 
-  # ${CLI} exec -i <HEKETI_POD> -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
+  # ${CLI} exec -i ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
 
 For dynamic provisioning, create a StorageClass similar to this:
 


### PR DESCRIPTION
Heketi service is created in k8s with ClusterIP type so it is not available from the outside unless we're using a proxy. Instead of that we run the `curl` command probe from a pod in the `deploy-heketi` deployment

Fixes https://github.com/gluster/gluster-kubernetes/issues/412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/414)
<!-- Reviewable:end -->
