### PR TITLE
wait for kubernetes before trying to deploy weave

### DIFF
--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -64,6 +64,13 @@
       group: vagrant
   when: not kubelet.stat.exists
 
+- name: wait for k8s to be ready
+  wait_for:
+    host: localhost
+    port: 6443
+    state: started
+    timeout: 60
+
 - name: create weave network
   command: kubectl apply -f https://git.io/weave-kube-1.6
 


### PR DESCRIPTION
This fixes an issue I was hitting with mutltiple runs. Usually the
first run of the playbooks would work fine but if a different issue
was hit and I neded to re-run them I kept hitting errors on
the weave step related to connection failures. This change adds a
wait for the port to be available before running that troublesome
step.

Signed-off-by: John Mulligan <jmulligan@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/416)
<!-- Reviewable:end -->
