### PR TITLE
vagrant: use a matching version of Weave Net

### DIFF
--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -71,8 +71,12 @@
     state: started
     timeout: 60
 
+- name: get k8s server and client versions
+  command: kubectl version
+  register: kubectl_version
+
 - name: create weave network
-  command: kubectl apply -f https://git.io/weave-kube-1.6
+  command: kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version={{ kubectl_version.stdout | b64encode }}"
 
 # jsonpath tested with kubeadm 1.6, 1.7, 1.8 
 - name: get dns service address


### PR DESCRIPTION
While deploying the Vagrant environment, Kubernetes 1.9.2 is currently
used. This version does not seem to be compatible with the 1.6 version
of Weave Net. While the weave- pods are starting, the following errors
are reported:

  dockerd-current[6461]: ERROR: logging before flag.Parse: E0119 15:50:15.165210    9894 reflector.go:205] github.com/weaveworks/weave/prog/weave-npc/main.go:230: Failed to list *v1.NetworkPolicy: networkpolicies.networking.k8s.io is forbidden: User "system:serviceaccount:kube-system:weave-net" cannot list networkpolicies.networking.k8s.io at the cluster scope

By using the recommended way to install the add-on, a matching version
will automatically be picked.

URL: https://www.weave.works/docs/net/latest/kubernetes/kube-addon/
Suggested-by: John Mulligan <jmulligan@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/421)
<!-- Reviewable:end -->
