### PR TITLE
vagrant: configure VMs with 2BG RAM

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
             vb.cpus = 2
         end
         master.vm.provider :libvirt do |lv|
-            lv.memory = 1024
+            lv.memory = 2048
             lv.cpus = 2
             lv.volume_cache = LIBVIRT_DISK_CACHE
         end
@@ -68,13 +68,13 @@ Vagrant.configure("2") do |config|
                         vb.customize [ "createmedium", "--filename", "disk-#{i}-#{d}.vdi", "--size", 1024*1024 ]
                     end
                     vb.customize [ "storageattach", :id, "--storagectl", "VboxSata", "--port", 3+d, "--device", 0, "--type", "hdd", "--medium", "disk-#{i}-#{d}.vdi" ]
-                    vb.memory = 1024
+                    vb.memory = 2048
                     vb.cpus = 2
                 end
                 node.vm.provider :libvirt do  |lv|
                     driverletters = ('b'..'z').to_a
                     lv.storage :file, :device => "vd#{driverletters[d]}", :path => "atomic-disk-#{i}-#{d}.disk", :size => '1024G'
-                    lv.memory = 1024
+                    lv.memory = 2048
                     lv.cpus =2
                     lv.volume_cache = LIBVIRT_DISK_CACHE
                 end


### PR DESCRIPTION
I used the VMs for building custom @heketi containers, maybe that also caused some additional memory problems. Except for messages in `dmesg`, none of the logs suggested OOM troubles, it was annoying to find the cause.

1GB seems a little on the low end, but 2GB might be a little much in case others have less powerful systems to develop on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/423)
<!-- Reviewable:end -->
