### PR TITLE
gk-deploy: check if heketi in the pod can support the --single-node option

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -845,6 +845,12 @@ if [[ ${EXISTS_DEPLOY_HEKETI} -eq 1 ]] && [[ ${EXISTS_HEKETI} -eq 0 ]]; then
     durability=''
     if [ ${SINGLE_NODE} -eq 1 ] ; then
       durability='--durability=none'
+      eval_output "${heketi_cli} setup-openshift-heketi-storage --help ${durability} 2>&1"
+      if [[ ${?} != 0 ]]; then
+        output "Not able to setup openshift heketi storage with ${durability}"
+        output "This indicates that the heketi running in the pod does not support single-node deployments."
+        exit 1
+      fi
     fi
     eval_output "${heketi_cli} setup-openshift-heketi-storage --listfile=/tmp/heketi-storage.json ${durability} 2>&1"
     if [[ ${?} != 0 ]]; then


### PR DESCRIPTION
Currently there is no Heketi release available that supports the
--durability option for the 'heketi-cli setup-openshift-heketi-storage'
command. In order to give the users a meaningful error message, add a
check to see if the --durability=none option is accepted. This is done
in combination with the --help option, which will just exit successfully
in case the options are valid, or exit with an error otherwise.

Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/427)
<!-- Reviewable:end -->
