### PR TITLE
vagrant: use 'host-passthrough' for CPU in the VMs

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -13,6 +13,12 @@ Vagrant.configure("2") do |config|
     # Override
     config.vm.provider :libvirt do |v,override|
         override.vm.synced_folder '.', '/home/vagrant/sync', disabled: true
+
+        # change cpu mode to passthrough as workaround, refer bugs:
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1467599
+        #https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
+        #vagrant-libvirt/vagrant-libvirt#667
+        v.cpu_mode = 'host-passthrough'
     end
 
     # Make kube master


### PR DESCRIPTION
On occasion the vagrant tests fail in the CentOS CI with the following
error:

  Call to virDomainCreateWithFlags failed: the CPU is incompatible with
  host CPU: Host CPU does not provide required features: svm

See-also: https://bugzilla.redhat.com/show_bug.cgi?id=1467599
See-also: https://bugzilla.redhat.com/show_bug.cgi?id=1386223#c10
See-also: vagrant-libvirt/vagrant-libvirt#667
Signed-off-by: Niels de Vos <ndevos@redhat.com>