### PR TITLE
Add HEKETI_IGNORE_STALE_OPERATIONS env variable in heketi. Helps to d…

### DIFF
--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -52,6 +52,8 @@ spec:
           value: '14'
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET
           value: "y"
+        - name: HEKETI_IGNORE_STALE_OPERATIONS
+          value: "true"
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -52,6 +52,8 @@ spec:
           value: '14'
         - name: HEKETI_KUBE_GLUSTER_DAEMONSET
           value: "y"
+        - name: HEKETI_IGNORE_STALE_OPERATIONS
+          value: "true"
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/deploy/ocp-templates/deploy-heketi-template.yaml
+++ b/deploy/ocp-templates/deploy-heketi-template.yaml
@@ -78,6 +78,8 @@ objects:
             value: '14'
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
             value: "y"
+          - name: HEKETI_IGNORE_STALE_OPERATIONS
+            value: "true"
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -117,3 +119,6 @@ parameters:
   displayName: heketi fstab path
   description: Set the fstab path, file that is populated with bricks that heketi creates
   value: /var/lib/heketi/fstab
+- name: HEKETI_IGNORE_STALE_OPERATIONS
+  displayName: Whether to ignore stale operations at startup
+  description: This allows to control whether heketi should start up when there are stale pending operation entries present in the database. Setting this to true lets heketi ignore existing pending operations at startup. Setting it to false causes heketi to refuse to start if pending operations are found in the database.

--- a/deploy/ocp-templates/heketi-template.yaml
+++ b/deploy/ocp-templates/heketi-template.yaml
@@ -79,6 +79,8 @@ objects:
             value: '14'
           - name: HEKETI_KUBE_GLUSTER_DAEMONSET
             value: "y"
+          - name: HEKETI_IGNORE_STALE_OPERATIONS
+            value: "true"
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -121,3 +123,6 @@ parameters:
   displayName: heketi fstab path
   description: Set the fstab path, file that is populated with bricks that heketi creates
   value: /var/lib/heketi/fstab
+- name: HEKETI_IGNORE_STALE_OPERATIONS
+  displayName: Whether to ignore stale operations at startup
+  description: This allows to control whether heketi should start up when there are stale pending operation entries present in the database. Setting this to true lets heketi ignore existing pending operations at startup. Setting it to false causes heketi to refuse to start if pending operations are found in the database.


### PR DESCRIPTION
…ecide whether to ignore the stale pending operations db entries in the database.

Default value is  true.

Signed-off-by: Saravanakumar <sarumuga@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/447)
<!-- Reviewable:end -->
