### PR TITLE
Add centos-ci build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gluster-kubernetes
 
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=gluster_kubernetes)](https://ci.centos.org/job/gluster_kubernetes)
+
 ## GlusterFS Native Storage Service for Kubernetes
 
 **gluster-kubernetes** is a project to provide Kubernetes administrators a


### PR DESCRIPTION
The centos-ci jenkins instance supports badge icons. Putting this status badge on the project raises the visibility of the health of the periodic builds.