### PR TITLE
Let the glusterfs pod load kernel modules

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -55,6 +55,9 @@ spec:
         - name: glusterfs-ssl
           mountPath: "/etc/ssl"
           readOnly: true
+        - name: kernel-modules
+          mountPath: "/usr/lib/modules"
+          readOnly: true
         securityContext:
           capabilities: {}
           privileged: true
@@ -109,3 +112,6 @@ spec:
       - name: glusterfs-ssl
         hostPath:
           path: "/etc/ssl"
+      - name: kernel-modules
+        hostPath:
+          path: "/usr/lib/modules"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -68,6 +68,9 @@ objects:
           - name: glusterfs-ssl
             mountPath: "/etc/ssl"
             readOnly: true
+          - name: kernel-modules
+            mountPath: "/usr/lib/modules"
+            readOnly: true
           securityContext:
             capabilities: {}
             privileged: true
@@ -124,6 +127,9 @@ objects:
         - name: glusterfs-ssl
           hostPath:
             path: "/etc/ssl"
+        - name: kernel-modules
+          hostPath:
+            path: "/usr/lib/modules"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
In certain cases the required kernel modules for creating thin-provisioned LVM Logical Volumes are not loaded. The lvm tools will cause automatic loading of the modules, but this will fail if the  `.ko` files are not available in the pod where the lvm command (likely `lvcreate`) is executed.

An example of these errors that is happening in the CentOS CI:
```
07:21:38 /usr/bin/kubectl -n default exec -i deploy-heketi-6c7d48f8b-jnx68 -- heketi-cli -s http://localhost:8080 --user admin --secret '' setup-openshift-heketi-storage --listfile=/tmp/heketi-storage.json  2>&1
07:21:53 Error: Unable to execute command on glusterfs-gg9h7:   /usr/sbin/modprobe failed: 1
07:21:53 thin: Required device-mapper target(s) not detected in your kernel.
07:21:53 Run `lvcreate --help' for more information.
07:21:53 command terminated with exit code 255
07:21:53 Failed on setup openshift heketi storage
07:21:53 This may indicate that the storage must be wiped and the GlusterFS nodes must be reset.
```

By bind-mounting `/usr/lib/modules` into the pod, the loading of the kernel modules is now possible.