### PR TITLE
Automatically create a dynamically provisioning StorageClass

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -49,6 +49,8 @@ OBJ_USER=""
 OBJ_PASSWORD=""
 OBJ_STORAGE_CLASS="glusterfs-for-s3"
 OBJ_CAPACITY="2Gi"
+CREATE_DYNAMIC_SC=0
+DYNAMIC_STORAGE_CLASS="glusterfs-storage"
 
 usage() {
   echo -e "USAGE: ${PROG} [-ghvy] [-c CLI] [-t <TEMPLATES>] [-n NAMESPACE] [-w <SECONDS>]
@@ -57,7 +59,8 @@ usage() {
        [--daemonset-label <DAEMONSET_LABEL> ] [--single-node] [--no-object]
        [--object-account <ACCOUNT>] [--object-user <USER>]
        [--object-password <PASSWORD>] [--object-sc <STORAGE_CLASS>]
-       [--object-capacity <CAPACITY>] [-l <LOG_FILE>] [--abort] [<TOPOLOGY>]\n"
+       [--object-capacity <CAPACITY>] [--create-dynamic-sc]
+       [--dynamic-sc <DYNAMIC_STORAGE_CLASS>] [-l <LOG_FILE>] [--abort] [<TOPOLOGY>]\n"
 }
 
 help_exit() {
@@ -143,6 +146,12 @@ Options:
   --object-capacity CAPACITY
               The total capacity of the GlusterFS volume which will store the
               object data. Default is '${OBJ_CAPACITY}'.
+
+  --create-dynamic-sc
+              Create a dynamicly provisioning StorageClass. Default is not to create.
+
+  --dynamic-sc DYNAMIC_STORAGE_CLASS
+              The metadata name of the StorageClass to create. Default is '${DYNAMIC_STORAGE_CLASS}'.
 
   -y, --yes
               Skip the pre-requisites prompt.
@@ -494,6 +503,15 @@ while [[ $# -ge 1 ]]; do
         ;;
         -object-capacity*)
         OBJ_CAPACITY=$(assign "${key:${keypos}}" "${2}")
+        if [[ $? -eq 2 ]]; then shift; fi
+        keypos=$keylen
+        ;;
+        -create-dynamic-sc)
+        CREATE_DYNAMIC_SC=1
+        keypos=$keylen
+        ;;
+        -dynamic-sc*)
+        DYNAMIC_STORAGE_CLASS=$(assign "${key:${keypos}}" "${2}")
         if [[ $? -eq 2 ]]; then shift; fi
         keypos=$keylen
         ;;
@@ -942,10 +960,11 @@ administrative commands you can install 'heketi-cli' and use it as follows:
 You can find it at https://github.com/heketi/heketi/releases . Alternatively,
 use it from within the heketi pod:
 
-  # ${CLI} exec -i ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list
+  # ${CLI} exec -i ${heketi_pod} -- heketi-cli -s http://localhost:8080 --user admin --secret '<ADMIN_KEY>' cluster list"
 
-For dynamic provisioning, create a StorageClass similar to this:
 
+if [[ ${CREATE_DYNAMIC_SC} -eq 0 ]]; then
+output "For dynamic provisioning, create a StorageClass similar to this:
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
@@ -958,9 +977,22 @@ parameters:
     output "  restuser: \"user\"
   restuserkey: \"${USER_KEY}\""
   fi
+fi
   output ""
 fi
 
+if [[ ${CREATE_DYNAMIC_SC} -eq 1 ]]; then
+  if [[ "x${USER_KEY}" != "x" ]]; then
+    # REST API Security is enabled - Append "restuser" and "restuserkey" to the StorageClass yaml
+cat <<EOF >> ${TEMPLATES}/gluster-dynamic-storageclass.yaml
+  restuser: "admin"
+  restuserkey: "${ADMIN_KEY}"
+EOF
+    eval_output "sed -e 's/\\\${STORAGE_CLASS}/${DYNAMIC_STORAGE_CLASS}/' -e 's/\\\${HEKETI_URL}/${heketi_service}/' -e 's/\\\${NAMESPACE}/${NAMESPACE}/' ${TEMPLATES}/gluster-dynamic-storageclass.yaml | ${CLI} create -f - 2>&1"
+  else
+    eval_output "sed -e 's/\\\${STORAGE_CLASS}/${DYNAMIC_STORAGE_CLASS}/' -e 's/\\\${HEKETI_URL}/${heketi_service}/' -e 's/\\\${NAMESPACE}/${NAMESPACE}/' ${TEMPLATES}/gluster-dynamic-storageclass.yaml | ${CLI} create -f - 2>&1"
+  fi
+fi
 
 if [[ ${DEPLOY_OBJECT} -eq 1 ]] && [[ "${OBJ_ACCOUNT}" != "" ]] && [[ "${OBJ_USER}" != "" ]] && [[ "${OBJ_PASSWORD}" != "" ]] && [[ ${EXISTS_OBJECT} -eq 0 ]]; then
   if [[ "${OBJ_STORAGE_CLASS}" == "glusterfs-for-s3" ]]; then

--- a/deploy/kube-templates/gluster-dynamic-storageclass.yaml
+++ b/deploy/kube-templates/gluster-dynamic-storageclass.yaml
@@ -1,0 +1,8 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: ${STORAGE_CLASS}
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://${HEKETI_URL}"


### PR DESCRIPTION
Add option to automatically create a dynamically provisioning StorageClass after the GlusterFS daemon-set deployment has completed.

To automatically create a StorageClass named: `glusterfs-storage`

```
./gk-deploy --yes --deploy-gluster --namespace glusterfs --create-dynamic-sc
```

To automatically create a StorageClass named: `glusterfs-ssd-storage`

```
./gk-deploy --yes --deploy-gluster --namespace glusterfs --create-dynamic-sc --dynamic-sc "glusterfs-ssd-storage"
```

I don't have access to an OpenShift cluster to test this against so I didn't include the template for OpenShift.

