### PR TITLE
gk_deploy: add --show-all switch to kubectl call

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -340,7 +340,7 @@ check() {
       break
     fi
     sleep 2
-    res=$(${CLI} get "${resource}" --no-headers "${select}" 2>/dev/null)
+    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2>/dev/null)
     if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
       reslines=$(echo "$res" | wc -l)
       ((reslines+=1))


### PR DESCRIPTION
Inside gk_deploy script, in check() function definition, when calling kubectl to check if one of the jobs has finished, the call is missing "--show-all" so it also shows jobs that are in `Completed` status, otherwise if the job has finished it is not listed and the script keeps waiting, eventually timing out.

Sample output:
```
$ kubectl get pods --no-headers -l job-name=heketi-storage-copy-job
No resources found, use --show-all to see completed objects.
$ kubectl get pods --show-all --no-headers -l job-name=heketi-storage-copy-job
heketi-storage-copy-job-8nfz7   0/1       Completed   0         19m
```