### PR TITLE
[RFC] deploy: if available, use new probe script in the glusterfs container image

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - systemctl status glusterd.service
+            - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh readiness; else systemctl status glusterd.service; fi"
           periodSeconds: 25
           successThreshold: 1
           failureThreshold: 50
@@ -79,7 +79,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - systemctl status glusterd.service
+            - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh liveness; else systemctl status glusterd.service; fi"
           periodSeconds: 25
           successThreshold: 1
           failureThreshold: 50

--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -24,6 +24,10 @@ spec:
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:
+        # set GLUSTER_BLOCKD_STATUS_PROBE_ENABLE to "1" so the
+        # readiness/liveness probe validate gluster-blockd as well
+        - name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
+          value: "1"
         - name: GB_GLFS_LRU_COUNT
           value: "15"
         - name: TCMU_LOGDIR

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -37,6 +37,8 @@ objects:
           imagePullPolicy: IfNotPresent
           name: glusterfs
           env:
+          - name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
+            value: "${GLUSTER_BLOCKD_STATUS_PROBE_ENABLE}"
           - name: GB_GLFS_LRU_COUNT
             value: "${GB_GLFS_LRU_COUNT}"
           - name: TCMU_LOGDIR
@@ -139,6 +141,11 @@ parameters:
   displayName: Daemonset Storage Node Label
   description: This is the value that will be used for the storagenode label in the daemonset node selector.
   value: glusterfs
+- name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
+  displayName: Enable readiness/liveness probe for gluster-blockd
+  description: Setting the value to "1" enables the readiness/liveness probe for gluster-blockd.
+  value: "1"
+  required: false
 - name: GB_GLFS_LRU_COUNT
   displayName: Maximum number of block hosting volumes
   description: This value is to set maximum number of block hosting volumes.

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -81,7 +81,7 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - systemctl status glusterd.service
+            - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh readiness; else systemctl status glusterd.service; fi"
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 50
@@ -92,7 +92,7 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - systemctl status glusterd.service
+            - "if command -v /usr/local/bin/status-probe.sh; then /usr/local/bin/status-probe.sh liveness; else systemctl status glusterd.service; fi"
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 50


### PR DESCRIPTION

If the probe script does not exist the statement falls back to the
previous method of checking only the status of glusterd.

This should only be merged if https://github.com/gluster/gluster-containers/pull/105 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/523)
<!-- Reviewable:end -->
