### PR TITLE
more reliable passing of the complex tests

### DIFF
--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -1,21 +1,4 @@
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: deploy-heketi
-  labels:
-    glusterfs: heketi-service
-    deploy-heketi: service
-  annotations:
-    description: Exposes Heketi Service
-spec:
-  selector:
-    deploy-heketi: pod
-  ports:
-  - name: deploy-heketi
-    port: 8080
-    targetPort: 8080
----
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
@@ -78,3 +61,20 @@ spec:
       - name: config
         secret:
           secretName: heketi-config-secret
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: deploy-heketi
+  labels:
+    glusterfs: heketi-service
+    deploy-heketi: service
+  annotations:
+    description: Exposes Heketi Service
+spec:
+  selector:
+    deploy-heketi: pod
+  ports:
+  - name: deploy-heketi
+    port: 8080
+    targetPort: 8080

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -1,21 +1,4 @@
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: heketi
-  labels:
-    glusterfs: heketi-service
-    heketi: service
-  annotations:
-    description: Exposes Heketi Service
-spec:
-  selector:
-    glusterfs: heketi-pod
-  ports:
-  - name: heketi
-    port: 8080
-    targetPort: 8080
----
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
@@ -81,3 +64,20 @@ spec:
       - name: config
         secret:
           secretName: heketi-config-secret
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: heketi
+  labels:
+    glusterfs: heketi-service
+    heketi: service
+  annotations:
+    description: Exposes Heketi Service
+spec:
+  selector:
+    glusterfs: heketi-pod
+  ports:
+  - name: heketi
+    port: 8080
+    targetPort: 8080

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - block:
   - name: kubeadm init
-    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+    command: kubeadm init --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
 
   - name: create root kube dir
     file:


### PR DESCRIPTION
New versions of Kubernetes' kubeadm do not have the
--skip-preflight-check option anymore. It has been replaced with
--ignore-preflight-errors. While testing, it seems this flag is not
needed anymore, tests can continue without it.

However, the updated Kubernetes versions seem more strict about the
order of objects in the .yaml files. There are two instances where the
Service refers to a Pod that is defined later on. This seems to prevent
the Service from getting created. Moving the Service definition to the
end, and tests pass again.

See-also: https://github.com/kubernetes/kubernetes/commit/3a0aa06fc9cb78738ba542db6154f71f5d1b92ea