### PR TITLE
added "--show-all" flag to stop hanging

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -13,7 +13,7 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+set -x
 PROG="$(basename "${0}")"
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 TOPOLOGY='topology.json'

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -13,7 +13,7 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -x
+
 PROG="$(basename "${0}")"
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 TOPOLOGY='topology.json'

--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -340,7 +340,7 @@ check() {
       break
     fi
     sleep 2
-    res=$(${CLI} get "${resource}" --no-headers "${select}" 2>/dev/null)
+    res=$(${CLI} get "${resource}" --no-headers --show-all "${select}" 2>/dev/null)
     if [[ ${s} -ne 0 ]] && [[ ${VERBOSE} -eq 1 ]]; then
       reslines=$(echo "$res" | wc -l)
       ((reslines+=1))


### PR DESCRIPTION
We were experiencing a hang because of a missing flag.

Environment
Provider: Digital Ocean
Machine: Ubuntu 16.04LTS
K8s version: 
Client Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.0", GitCommit:"0ed33881dc4355495f623c6f22e7dd0b7632b7c0", GitTreeState:"clean", BuildDate:"2018-09-27T17:05:32Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.0", GitCommit:"0ed33881dc4355495f623c6f22e7dd0b7632b7c0", GitTreeState:"clean", BuildDate:"2018-09-27T16:55:41Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/525)
<!-- Reviewable:end -->
