### PR TITLE
bind mount /var/lib/gluster-block to pod [WIP]

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -62,6 +62,8 @@ spec:
         - name: kernel-modules
           mountPath: "/usr/lib/modules"
           readOnly: true
+        - name: gluster-block
+          mountPath: "/var/lib/gluster-block"
         securityContext:
           capabilities: {}
           privileged: true
@@ -119,3 +121,6 @@ spec:
       - name: kernel-modules
         hostPath:
           path: "/usr/lib/modules"
+      - name: gluster-block
+        hostPath:
+          path: "/var/lib/gluster-block"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -73,6 +73,8 @@ objects:
           - name: kernel-modules
             mountPath: "/usr/lib/modules"
             readOnly: true
+          - name: gluster-block
+            mountPath: "/var/lib/gluster-block"
           securityContext:
             capabilities: {}
             privileged: true
@@ -132,6 +134,9 @@ objects:
         - name: kernel-modules
           hostPath:
             path: "/usr/lib/modules"
+        - name: gluster-block
+          hostPath:
+            path: "/var/lib/gluster-block"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
bind mount /var/lib/gluster-block to pod.
This way status file for gluster-block can be persistent.

Signed-off-by: Saravanakumar <sarumuga@redhat.com>