### PR TITLE
deploy: no need to have volumes for /dev in privileged containers

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -49,8 +49,6 @@ spec:
           mountPath: "/var/log/glusterfs"
         - name: glusterfs-config
           mountPath: "/var/lib/glusterd"
-        - name: glusterfs-dev
-          mountPath: "/dev"
         - name: glusterfs-misc
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
@@ -104,9 +102,6 @@ spec:
       - name: glusterfs-config
         hostPath:
           path: "/var/lib/glusterd"
-      - name: glusterfs-dev
-        hostPath:
-          path: "/dev"
       - name: glusterfs-misc
         hostPath:
           path: "/var/lib/misc/glusterfsd"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -60,8 +60,6 @@ objects:
             mountPath: "/var/log/glusterfs"
           - name: glusterfs-config
             mountPath: "/var/lib/glusterd"
-          - name: glusterfs-dev
-            mountPath: "/dev"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -117,9 +115,6 @@ objects:
         - name: glusterfs-config
           hostPath:
             path: "/var/lib/glusterd"
-        - name: glusterfs-dev
-          hostPath:
-            path: "/dev"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
It seems recent versions of CRI-O cause problems when bind-mounting /dev
into a privileged container. When a container is privileged, it
automatically gets access to /dev, a bind-mount is setup by the runtime.

With the new CRI-O versions, the following error is reported and the
containers fail to start:

  Warning  Unhealthy  1m (x346 over 1h)  kubelet, cnv-executor-lbednar-node2.example.com  (combined from similar events): Liveness probe errored: rpc error: code = Unknown desc = command error: time="2018-11-15T14:27:20Z" level=error msg="open /dev/null: permission denied
  "
  open /dev/null: permission denied
  exec failed: container_linux.go:336: starting container process caused "read init-p: connection reset by peer"
  , stdout: , stderr: , exit code -1

Fixes: https://bugzilla.redhat.com/1651270
Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/538)
<!-- Reviewable:end -->
