### PR TITLE
deploy: bind-mount /dev/disk into the glusterfs-server container

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -49,6 +49,8 @@ spec:
           mountPath: "/var/log/glusterfs"
         - name: glusterfs-config
           mountPath: "/var/lib/glusterd"
+        - name: glusterfs-dev-disk
+          mountPath: "/dev/disk"
         - name: glusterfs-misc
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
@@ -102,6 +104,9 @@ spec:
       - name: glusterfs-config
         hostPath:
           path: "/var/lib/glusterd"
+      - name: glusterfs-dev-disk
+        hostPath:
+          path: "/dev/disk"
       - name: glusterfs-misc
         hostPath:
           path: "/var/lib/misc/glusterfsd"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -60,6 +60,8 @@ objects:
             mountPath: "/var/log/glusterfs"
           - name: glusterfs-config
             mountPath: "/var/lib/glusterd"
+          - name: glusterfs-dev-disk
+            mountPath: "/dev/disk"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -115,6 +117,9 @@ objects:
         - name: glusterfs-config
           hostPath:
             path: "/var/lib/glusterd"
+        - name: glusterfs-dev-disk
+          hostPath:
+            path: "/dev/disk"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
Commit 2f1114a removed the bind-mount for /dev as this will be setup by
the container runtime automatically. However it seems that /dev/disk is
missing, prevending users to supply /dev/disk/by-id/* device names to
Heketi.

This change adds /dev/disk as an additional bind-mount. CRI-O does
prevent /dev to be bind-mounted, but subdirectories of /dev do not seem
to be an issue.

Reported-by: Gal Ben Haim <gbenhaim@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/542)
<!-- Reviewable:end -->
