### PR TITLE
deploy: bind-mount /dev/mapper into the glusterfs-server container

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -51,6 +51,8 @@ spec:
           mountPath: "/var/lib/glusterd"
         - name: glusterfs-dev-disk
           mountPath: "/dev/disk"
+        - name: glusterfs-dev-mapper
+          mountPath: "/dev/mapper"
         - name: glusterfs-misc
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
@@ -107,6 +109,9 @@ spec:
       - name: glusterfs-dev-disk
         hostPath:
           path: "/dev/disk"
+      - name: glusterfs-dev-mapper
+        hostPath:
+          path: "/dev/mapper"
       - name: glusterfs-misc
         hostPath:
           path: "/var/lib/misc/glusterfsd"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -62,6 +62,8 @@ objects:
             mountPath: "/var/lib/glusterd"
           - name: glusterfs-dev-disk
             mountPath: "/dev/disk"
+          - name: glusterfs-dev-mapper
+            mountPath: "/dev/mapper"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -120,6 +122,9 @@ objects:
         - name: glusterfs-dev-disk
           hostPath:
             path: "/dev/disk"
+        - name: glusterfs-dev-mapper
+          hostPath:
+            path: "/dev/mapper"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"


### PR DESCRIPTION
Commit 2f1114a removed the bind-mount for /dev as this will be setup by
the container runtime automatically. However it seems that /dev/mapper
is missing, prevending users to supply /dev/mapper/* device names to
Heketi. It also seems possible that not all(?) LVM devices are available
when a container starts.

This change adds /dev/mapper as an additional bind-mount. CRI-O does
prevent /dev to be bind-mounted, but subdirectories of /dev do not seem
to be an issue.

Fixes: #499
Signed-off-by: Niels de Vos <ndevos@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/544)
<!-- Reviewable:end -->
