### PR TITLE
gluster-block needs to dynamically create /dev/uio* devices

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -24,6 +24,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: glusterfs
         env:
+        # alternative for /dev volumeMount to enable access to *all* devices
+        - name: HOST_DEV_DIR
+          value: "/mnt/host-dev"
         # set GLUSTER_BLOCKD_STATUS_PROBE_ENABLE to "1" so the
         # readiness/liveness probe validate gluster-blockd as well
         - name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
@@ -49,10 +52,8 @@ spec:
           mountPath: "/var/log/glusterfs"
         - name: glusterfs-config
           mountPath: "/var/lib/glusterd"
-        - name: glusterfs-dev-disk
-          mountPath: "/dev/disk"
-        - name: glusterfs-dev-mapper
-          mountPath: "/dev/mapper"
+        - name: glusterfs-host-dev
+          mountPath: "/mnt/host-dev"
         - name: glusterfs-misc
           mountPath: "/var/lib/misc/glusterfsd"
         - name: glusterfs-cgroup
@@ -106,12 +107,9 @@ spec:
       - name: glusterfs-config
         hostPath:
           path: "/var/lib/glusterd"
-      - name: glusterfs-dev-disk
+      - name: glusterfs-host-dev
         hostPath:
-          path: "/dev/disk"
-      - name: glusterfs-dev-mapper
-        hostPath:
-          path: "/dev/mapper"
+          path: "/dev"
       - name: glusterfs-misc
         hostPath:
           path: "/var/lib/misc/glusterfsd"

--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -56,6 +56,10 @@ spec:
           mountPath: "/mnt/host-dev"
         - name: glusterfs-misc
           mountPath: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-block-sys-class
+          mountPath: "/sys/class"
+        - name: glusterfs-block-sys-module
+          mountPath: "/sys/module"
         - name: glusterfs-cgroup
           mountPath: "/sys/fs/cgroup"
           readOnly: true
@@ -113,6 +117,12 @@ spec:
       - name: glusterfs-misc
         hostPath:
           path: "/var/lib/misc/glusterfsd"
+      - name: glusterfs-block-sys-class
+        hostPath:
+          path: "/sys/class"
+      - name: glusterfs-block-sys-module
+        hostPath:
+          path: "/sys/module"
       - name: glusterfs-cgroup
         hostPath:
           path: "/sys/fs/cgroup"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -66,6 +66,10 @@ objects:
             mountPath: "${HOST_DEV_DIR}"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
+          - name: glusterfs-block-sys-class
+            mountPath: "/sys/class"
+          - name: glusterfs-block-sys-module
+            mountPath: "/sys/module"
           - name: glusterfs-cgroup
             mountPath: "/sys/fs/cgroup"
             readOnly: true
@@ -125,6 +129,12 @@ objects:
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"
+        - name: glusterfs-block-sys-class
+          hostPath:
+            path: "/sys/class"
+        - name: glusterfs-block-sys-module
+          hostPath:
+            path: "/sys/module"
         - name: glusterfs-cgroup
           hostPath:
             path: "/sys/fs/cgroup"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -37,6 +37,8 @@ objects:
           imagePullPolicy: IfNotPresent
           name: glusterfs
           env:
+          - name: HOST_DEV_DIR
+            value: "${HOST_DEV_DIR}"
           - name: GLUSTER_BLOCKD_STATUS_PROBE_ENABLE
             value: "${GLUSTER_BLOCKD_STATUS_PROBE_ENABLE}"
           - name: GB_GLFS_LRU_COUNT
@@ -60,10 +62,8 @@ objects:
             mountPath: "/var/log/glusterfs"
           - name: glusterfs-config
             mountPath: "/var/lib/glusterd"
-          - name: glusterfs-dev-disk
-            mountPath: "/dev/disk"
-          - name: glusterfs-dev-mapper
-            mountPath: "/dev/mapper"
+          - name: glusterfs-host-dev
+            mountPath: "${HOST_DEV_DIR}"
           - name: glusterfs-misc
             mountPath: "/var/lib/misc/glusterfsd"
           - name: glusterfs-cgroup
@@ -100,7 +100,7 @@ objects:
             periodSeconds: 25
             successThreshold: 1
             failureThreshold: 50
-          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePath: "/var/log/termination.log"
         volumes:
         - name: glusterfs-heketi
           hostPath:
@@ -119,12 +119,9 @@ objects:
         - name: glusterfs-config
           hostPath:
             path: "/var/lib/glusterd"
-        - name: glusterfs-dev-disk
+        - name: glusterfs-host-dev
           hostPath:
-            path: "/dev/disk"
-        - name: glusterfs-dev-mapper
-          hostPath:
-            path: "/dev/mapper"
+            path: "/dev"
         - name: glusterfs-misc
           hostPath:
             path: "/var/lib/misc/glusterfsd"
@@ -160,4 +157,9 @@ parameters:
   displayName: Tcmu runner log directory
   description: This value is to set tcmu runner log directory
   value: "/var/log/glusterfs/gluster-block"
+  required: true
+- name: HOST_DEV_DIR
+  displayName: Alternative path to /dev in the container
+  description: Volume mount point of /dev from the host so that the container can access all devices.
+  value: "/mnt/host-dev"
   required: true

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,6 +9,7 @@ LIBVIRT_DISK_CACHE = "default"
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
     config.vm.box = "centos/7"
+    config.vm.box_url = "https://app.vagrantup.com/centos/7"
 
     # Override
     config.vm.provider :libvirt do |v,override|

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -30,8 +30,17 @@
   register: kubelet
 
 - block:
+  - name: get parameters of kubeadm init
+    command: kubeadm init --help
+    register: kubeadm_init_help
+
+  - name: kubeadm needs deprecated --skip-preflight-checks
+    set_fact:
+      kubeadm_preflight: '--skip-preflight-checks'
+    when: kubeadm_init_help.stdout.find('--skip-preflight-checks') != -1
+
   - name: kubeadm init
-    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+    command: kubeadm init {{ kubeadm_preflight | default('--ignore-preflight-errors=all') }} --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
 
   - name: create root kube dir
     file:


### PR DESCRIPTION
By not bind-mounting /dev in the container anymore, gluster-block fails to create block-volumes. Unfortunately bind-mounting /dev is not possible with CRI-O, so we came up with a different approach to reach the same goal.

The gluster/gluster-container#115 change introduces a feature in the early start script for the glusterfs-server container. It is now possible to `mount --rbind` an alternative /dev from the host onto the /dev path in the container.

It also has been noticed that CRI-O secures `/sys` more than Docker does. tcmu-runner (part of gluster-block) needs write access to `/sys/module` and `/sys/class`.

With these two changes, gluster-block functions again on recent versions of OpenShift, both with Docker and CRI-O runtimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/545)
<!-- Reviewable:end -->
