### PR TITLE
Fix regression tests

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,6 +9,7 @@ LIBVIRT_DISK_CACHE = "default"
 Vagrant.configure("2") do |config|
     config.ssh.insert_key = false
     config.vm.box = "centos/7"
+    config.vm.box_url = "https://app.vagrantup.com/centos/7"
 
     # Override
     config.vm.provider :libvirt do |v,override|

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -30,8 +30,17 @@
   register: kubelet
 
 - block:
+  - name: get parameters of kubeadm init
+    command: kubeadm init --help
+    register: kubeadm_init_help
+
+  - name: kubeadm needs deprecated --skip-preflight-checks
+    set_fact:
+      kubeadm_preflight: '--skip-preflight-checks'
+    when: kubeadm_init_help.stdout.find('--skip-preflight-checks') != -1
+
   - name: kubeadm init
-    command: kubeadm init --skip-preflight-checks --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
+    command: kubeadm init {{ kubeadm_preflight | default('--ignore-preflight-errors=all') }} --token={{ kubernetes_token }} --kubernetes-version=v{{ kube_ver.stdout }}  --apiserver-advertise-address={{ ansible_eth1.ipv4.address }}
 
   - name: create root kube dir
     file:


### PR DESCRIPTION
The current regression tests are failing due to two problems:

1. The CentOS version of Vagrant tries to download boxes from a wrong repository
2. Newer versions of `kubeadm` do not have `--skip-preflight-checks` anymore