### PR TITLE
install packages without loop in yum

### DIFF
--- a/vagrant/roles/common/tasks/main.yml
+++ b/vagrant/roles/common/tasks/main.yml
@@ -47,11 +47,10 @@
   # setup standard repos
   - name: install centos and epel repos
     yum:
-      name: "{{ item }}"
+      name:
+        - epel-release
+        - centos-release-gluster
       state: present
-    with_items:
-    - epel-release
-    - centos-release-gluster
 
   - name: setup kubernetes repo
     yum_repository:
@@ -79,11 +78,10 @@
 
 - name: install base packages
   yum:
-    name: "{{ item }}"
+    name: "{{ install_pkgs }}"
     state: present
     disable_gpg_check: yes
     update_cache: yes
-  with_items: "{{ install_pkgs }}"
 
 - name: Ensure net.bridge.bridge-nf-call-iptables is set. See kubeadm
   copy: src=k8s.conf owner=root group=root dest=/etc/sysctl.d/k8s.conf

--- a/vagrant/roles/master/tasks/gcr_proxy.yml
+++ b/vagrant/roles/master/tasks/gcr_proxy.yml
@@ -1,11 +1,10 @@
 ---
 - name: install ansible-docker depencendies
   yum:
-    name: "{{ item }}"
+    name:
+      - docker-python
     state: present
     disable_gpg_check: yes
-  with_items:
-  - docker-python
 
 - name: check for nginx-slim image
   uri:

--- a/vagrant/roles/master/tasks/main.yml
+++ b/vagrant/roles/master/tasks/main.yml
@@ -5,12 +5,11 @@
 
 - name: install s3-curl depencendies
   yum:
-    name: "{{ item }}"
+    name:
+      - perl-Digest-HMAC
+      - unzip
     state: present
     disable_gpg_check: yes
-  with_items:
-  - perl-Digest-HMAC
-  - unzip
 
 - name: get s3curl
   unarchive:


### PR DESCRIPTION
ansible shows a deprecated warning message with installing
packages with yum with loop

updated the task to install packages without a loop to fix this warning.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>