### PR TITLE
Correcting the modules path in order to support other distros

### DIFF
--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: "/etc/ssl"
           readOnly: true
         - name: kernel-modules
-          mountPath: "/usr/lib/modules"
+          mountPath: "/lib/modules"
           readOnly: true
         securityContext:
           capabilities: {}
@@ -131,4 +131,4 @@ spec:
           path: "/etc/ssl"
       - name: kernel-modules
         hostPath:
-          path: "/usr/lib/modules"
+          path: "/lib/modules"

--- a/deploy/ocp-templates/glusterfs-template.yaml
+++ b/deploy/ocp-templates/glusterfs-template.yaml
@@ -77,7 +77,7 @@ objects:
             mountPath: "/etc/ssl"
             readOnly: true
           - name: kernel-modules
-            mountPath: "/usr/lib/modules"
+            mountPath: "/lib/modules"
             readOnly: true
           securityContext:
             capabilities: {}
@@ -143,7 +143,7 @@ objects:
             path: "/etc/ssl"
         - name: kernel-modules
           hostPath:
-            path: "/usr/lib/modules"
+            path: "/lib/modules"
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst


### PR DESCRIPTION
This patch fixes #539. Not all supported distros have /lib as a symlink of
/usr/lib. For example, Ubuntu 18.04 doesn't. This causes an issue with
tcmu-runner; which requires target_core_user and other modules to be able to
build.

In order to fix this, we just need to mount `/lib/modules` instead so all of
the supported distributions are capable of the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/557)
<!-- Reviewable:end -->
