### PR TITLE
removed host key checking on ssh

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -676,7 +676,7 @@ if [[ "${EXECUTOR}" == "ssh" ]]; then
     fi
     # shellcheck disable=SC2029
     # I want this parsed client-side
-    ssh "${SSH_USER}@${node}" -q -i "${SSH_KEYFILE}" -C "${sudocmd}gluster volume status" >/dev/null 2>&1
+    ssh "${SSH_USER}@${node}" -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -q -i "${SSH_KEYFILE}" -C "${sudocmd}gluster volume status" >/dev/null 2>&1
     if [[ ${?} -ne 0 ]]; then
       output "Can't access glusterd on '${node}'"
       exit 1


### PR DESCRIPTION
I figure that there really isn't a reason to have host key checking enabled because this is an automated script. I've added the ssh arguments to remove the need for host keys being checked.