### PR TITLE
@kubectl@ --show-all option is defaulted to true and deprecated since 1.11 and removed since 1.14

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -916,7 +916,7 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+heketi_pod=$(${CLI} get pod --no-headers --selector="heketi" | awk '{print $1}')
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')


### PR DESCRIPTION
* deploy/gk-deploy : remove @--show-all@ option to @kubectl@ command line

` ~$ kubectl version`
`Client Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.0", GitCommit:"641856db18352033a0d96dbc99153fa3b27298e5", GitTreeState:"clean", BuildDate:"2019-03-25T15:53:57Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"linux/amd64"}`
`Server Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.0", GitCommit:"641856db18352033a0d96dbc99153fa3b27298e5", GitTreeState:"clean", BuildDate:"2019-03-25T15:45:25Z", GoVersion:"go1.12.1", Compiler:"gc", Platform:"linux/amd64"}`

`~$ kubectl get pods --show-all --no-headers -l job-name=heketi-storage-copy-job`
 `Error: unknown flag: --show-all`
....
`Use "kubectl options" for a list of global command-line options (applies to all commands).`

`unknown flag: --show-all`
