### PR TITLE
Failed to fetch heketi pod name

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -916,7 +916,7 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+heketi_pod=$(${CLI} get pod --no-headers --selector="heketi" | awk '{print $1}')
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')


### PR DESCRIPTION
--show-all is not a supported argument for kubectl get pod. This causes gk-deploy to fail with an error after successfully deploying.
