### PR TITLE
Removes unknown flag in K8S 1.13

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -916,7 +916,7 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+heketi_pod=$(${CLI} get pod --no-headers --selector="heketi" | awk '{print $1}')
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')


### PR DESCRIPTION
Hello,

This PR updates the gk-deploy script to work with Kubernetes v1.13, where "show-all" is unknown.

Hope this will help.
Cheers