### PR TITLE
remove the default secrets from the json template

### DIFF
--- a/deploy/heketi.json.template
+++ b/deploy/heketi.json.template
@@ -9,11 +9,11 @@
 	"jwt" : {
 		"_admin" : "Admin has access to all APIs",
 		"admin" : {
-			"key" : "My Secret"
+			"key" : ""
 		},
 		"_user" : "User only has access to /volumes endpoint",
 		"user" : {
-			"key" : "My Secret"
+			"key" : ""
 		}
 	},
 


### PR DESCRIPTION
We don't want to deploy heketi with default secrets.

Signed-off-by: Raghavendra Talur <rtalur@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/602)
<!-- Reviewable:end -->
