### PR TITLE
updated deprecated kubernetes 1.16 API endpoints. fixed selectors

### DIFF
--- a/deploy/gk-deploy
+++ b/deploy/gk-deploy
@@ -921,7 +921,7 @@ while [[ "x${heketi_service}" == "x" ]] || [[ "${heketi_service}" == "<none>" ]]
   heketi_service=$(${CLI} describe svc/heketi | grep "Endpoints:" | awk '{print $2}')
 done
 
-heketi_pod=$(${CLI} get pod --no-headers --show-all --selector="heketi" | awk '{print $1}')
+heketi_pod=$(${CLI} get pod --no-headers --selector="heketi" | awk '{print $1}')
 
 if [[ "${CLI}" == *oc\ * ]]; then
   heketi_service=$(${CLI} describe routes/heketi | grep "Requested Host:" | awk '{print $3}')

--- a/deploy/kube-templates/deploy-heketi-deployment.yaml
+++ b/deploy/kube-templates/deploy-heketi-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     targetPort: 8080
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: deploy-heketi
   labels:
@@ -26,6 +26,9 @@ metadata:
   annotations:
     description: Defines how to deploy Heketi
 spec:
+  selector:
+    matchLabels:
+      glusterfs: heketi-pod
   replicas: 1
   template:
     metadata:

--- a/deploy/kube-templates/gluster-s3-storageclass.yaml
+++ b/deploy/kube-templates/gluster-s3-storageclass.yaml
@@ -1,6 +1,6 @@
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: ${STORAGE_CLASS}
   labels:

--- a/deploy/kube-templates/gluster-s3-template.yaml
+++ b/deploy/kube-templates/gluster-s3-template.yaml
@@ -21,7 +21,7 @@ items:
   status:
     loadBalancer: {}
 - kind: Deployment
-  apiVersion: extensions/v1beta1
+  apiVersion: apps/v1
   metadata:
     name: gluster-s3-deployment
     labels:
@@ -30,6 +30,9 @@ items:
     annotations:
       description: Defines how to deploy gluster s3 object storage
   spec:
+    selector:
+      matchLabels:
+        glusterfs: s3-pod
     replicas: 1
     template:
       metadata:

--- a/deploy/kube-templates/glusterfs-daemonset.yaml
+++ b/deploy/kube-templates/glusterfs-daemonset.yaml
@@ -1,6 +1,6 @@
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: glusterfs
   labels:
@@ -9,6 +9,10 @@ metadata:
     description: GlusterFS DaemonSet
     tags: glusterfs
 spec:
+  selector:
+    matchLabels:
+      glusterfs: pod
+      glusterfs-node: pod
   template:
     metadata:
       name: glusterfs

--- a/deploy/kube-templates/heketi-deployment.yaml
+++ b/deploy/kube-templates/heketi-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     targetPort: 8080
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: heketi
   labels:
@@ -26,6 +26,9 @@ metadata:
   annotations:
     description: Defines how to deploy Heketi
 spec:
+  selector:
+    matchLabels:
+      glusterfs: heketi-pod
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
- updated deprecated and removed kubernetes API beta endpoints. (deprecated since 1.9 - 1.10, removed in 1.13 - 1.16)
- replaced with proper official endpoints (present since 1.9 - 1.10)
- fixed template selectors. (necessary since 1.16)
- removed deprecated kubectl --show-all argument

this is production tested with 1.16.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gluster/gluster-kubernetes/624)
<!-- Reviewable:end -->
